### PR TITLE
feat: support proxy set buffer bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ test:
 test.e2e:
 	docker run -it -w /tmp/proxy-wasm-go -v $(shell pwd):/tmp/proxy-wasm-go getenvoy/proxy-wasm-go-sdk-ci:istio-${ISTIO_VERSION} go test -v ./e2e
 
+test.e2e.single:
+	docker run -it -w /tmp/proxy-wasm-go -v $(shell pwd):/tmp/proxy-wasm-go getenvoy/proxy-wasm-go-sdk-ci:istio-${ISTIO_VERSION} go test -v ./e2e -run ${name}
+
 run:
 	docker run --entrypoint='/usr/local/bin/envoy' \
 		-p 18000:18000 -p 8099:8099 \

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -117,6 +117,28 @@ func TestE2E_http_headers(t *testing.T) {
 	assert.True(t, strings.Contains(out, "server: envoy"))
 }
 
+func TestE2E_http_body(t *testing.T) {
+	cmd, stdErr := startExample(t, "http_body")
+	defer func() {
+		require.NoError(t, cmd.Process.Kill())
+	}()
+
+	req, err := http.NewRequest("GET", envoyEndpoint, bytes.NewBuffer([]byte(`{ "example": "body" }`)))
+	require.NoError(t, err)
+
+	r, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer r.Body.Close()
+
+	out := stdErr.String()
+	fmt.Println(out)
+	assert.True(t, strings.Contains(out, "body size: 21"))
+	assert.True(t, strings.Contains(out, `initial request body: { "example": "body" }`))
+	assert.True(t, strings.Contains(out, "on http request body finished"))
+	assert.False(t, strings.Contains(out, "failed to set request body"))
+	assert.False(t, strings.Contains(out, "failed to get request body"))
+}
+
 func TestE2E_network(t *testing.T) {
 	cmd, stdErr := startExample(t, "network")
 	defer func() {

--- a/examples/http_body/README.md
+++ b/examples/http_body/README.md
@@ -1,4 +1,4 @@
-## http_headers
+## http_body
 
 this example replaces the request body
 

--- a/examples/http_body/README.md
+++ b/examples/http_body/README.md
@@ -1,0 +1,9 @@
+## http_headers
+
+this example replaces the request body
+
+```
+2020/10/12 13:41:31 proxy_info_log: body size: 29
+2020/10/12 13:41:31 proxy_info_log: initial request body: { "initial": "request body" }
+2020/10/12 13:41:31 proxy_info_log: on http request body finished
+```

--- a/examples/http_body/envoy.yaml
+++ b/examples/http_body/envoy.yaml
@@ -1,0 +1,82 @@
+static_resources:
+  listeners:
+    - name: main
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 18000
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: web_service
+                http_filters:
+                  - name: envoy.filters.http.wasm
+                    config:
+                      config:
+                        name: "my_plugin"
+                        root_id: "my_root_id"
+                        vm_config:
+                          vm_id: "my_vm_id"
+                          runtime: "envoy.wasm.runtime.v8"
+                          code:
+                            local:
+                              filename: "./examples/http_headers/main.go.wasm"
+                          allow_precompiled: true
+                  - name: envoy.router
+                    config: {}
+    - name: staticreply
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 8099
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          direct_response:
+                            status: 200
+                            body:
+                              inline_string: "example body\n"
+                http_filters:
+                  - name: envoy.router
+                    config: {}
+
+  clusters:
+    - name: web_service
+      connect_timeout: 0.25s
+      type: static
+      lb_policy: round_robin
+      hosts:
+        - socket_address:
+            address: 127.0.0.1
+            port_value: 8099
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/http_body/envoy.yaml
+++ b/examples/http_body/envoy.yaml
@@ -33,7 +33,7 @@ static_resources:
                           runtime: "envoy.wasm.runtime.v8"
                           code:
                             local:
-                              filename: "./examples/http_headers/main.go.wasm"
+                              filename: "./examples/http_body/main.go.wasm"
                           allow_precompiled: true
                   - name: envoy.router
                     config: {}

--- a/examples/http_body/main.go
+++ b/examples/http_body/main.go
@@ -36,22 +36,24 @@ func newContext(rootContextID, contextID uint32) proxywasm.HttpContext {
 // override
 func (ctx *httpBody) OnHttpRequestBody(bodySize int, endOfStream bool) types.Action {
 	proxywasm.LogInfof("body size: %d", bodySize)
+	if bodySize != 0 {
+		initialBody, err := proxywasm.GetHttpRequestBody(0, bodySize)
+		if err != nil {
+			proxywasm.LogErrorf("failed to get request body: %v", err)
+			return types.ActionContinue
+		}
+		proxywasm.LogInfof("initial request body: %s", string(initialBody))
 
-	b, err := proxywasm.GetHttpRequestBody(0, bodySize)
-	if err != nil {
-		proxywasm.LogErrorf("failed to get request body: %v", err)
-		return types.ActionContinue
+		b := []byte(`{ "another": "body" }`)
+
+		err = proxywasm.SetHttpRequestBody(b)
+		if err != nil {
+			proxywasm.LogErrorf("failed to set request body: %v", err)
+			return types.ActionContinue
+		}
+
+		proxywasm.LogInfof("on http request body finished")
 	}
-
-	proxywasm.LogInfof("initial request body: %s", string(b))
-
-	err = proxywasm.SetHttpRequestBody([]byte(`{"test":"data"}`))
-	if err != nil {
-		proxywasm.LogErrorf("failed to get request body: %v", err)
-		return types.ActionContinue
-	}
-
-	proxywasm.LogInfof("on http request body finished")
 
 	return types.ActionContinue
 }

--- a/examples/http_body/main.go
+++ b/examples/http_body/main.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func main() {
+	proxywasm.SetNewHttpContext(newContext)
+}
+
+type httpBody struct {
+	// you must embed the default context so that you need not to reimplement all the methods by yourself
+	proxywasm.DefaultHttpContext
+	contextID uint32
+}
+
+func newContext(rootContextID, contextID uint32) proxywasm.HttpContext {
+	return &httpBody{contextID: contextID}
+}
+
+// override
+func (ctx *httpBody) OnHttpRequestBody(bodySize int, endOfStream bool) types.Action {
+	proxywasm.LogInfof("body size: %d", bodySize)
+
+	b, err := proxywasm.GetHttpRequestBody(0, bodySize)
+	if err != nil {
+		proxywasm.LogErrorf("failed to get request body: %v", err)
+		return types.ActionContinue
+	}
+
+	proxywasm.LogInfof("initial request body: %s", string(b))
+
+	err = proxywasm.SetHttpRequestBody([]byte(`{"test":"data"}`))
+	if err != nil {
+		proxywasm.LogErrorf("failed to get request body: %v", err)
+		return types.ActionContinue
+	}
+
+	proxywasm.LogInfof("on http request body finished")
+
+	return types.ActionContinue
+}

--- a/examples/http_body/main_test.go
+++ b/examples/http_body/main_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
 )
 
-func TestHttpHeaders_OnHttpRequestHeaders(t *testing.T) {
+func TestHttpBody_OnHttpRequestBody(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
 		WithNewHttpContext(newContext)
 	host := proxytest.NewHostEmulator(opt)
@@ -19,7 +19,7 @@ func TestHttpHeaders_OnHttpRequestHeaders(t *testing.T) {
 	host.HttpFilterPutRequestBody(id, []byte(`{ "initial": "request body" }`))
 
 	res := host.HttpFilterGetRequestBody(id)
-	assert.Equal(t, `{"test":"data"}`, string(res))
+	assert.Equal(t, `{ "another": "body" }`, string(res))
 
 	logs := host.GetLogs(types.LogLevelInfo)
 	require.Greater(t, len(logs), 1)

--- a/examples/http_body/main_test.go
+++ b/examples/http_body/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxytest"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func TestHttpHeaders_OnHttpRequestHeaders(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().
+		WithNewHttpContext(newContext)
+	host := proxytest.NewHostEmulator(opt)
+	defer host.Done()
+
+	id := host.HttpFilterInitContext()
+	host.HttpFilterPutRequestBody(id, []byte(`{ "initial": "request body" }`))
+
+	res := host.HttpFilterGetRequestBody(id)
+	assert.Equal(t, `{"test":"data"}`, string(res))
+
+	logs := host.GetLogs(types.LogLevelInfo)
+	require.Greater(t, len(logs), 1)
+
+	assert.Equal(t, "on http request body finished", logs[len(logs)-1])
+	assert.Equal(t, `initial request body: { "initial": "request body" }`, logs[len(logs)-2])
+	assert.Equal(t, "body size: 29", logs[len(logs)-3])
+}

--- a/proxytest/proxytest.go
+++ b/proxytest/proxytest.go
@@ -116,6 +116,11 @@ func (h *hostEmulator) ProxyGetBufferBytes(bt types.BufferType, start int, maxSi
 	}
 }
 
+func (h *hostEmulator) ProxySetBufferBytes(bt types.BufferType, start int, maxSize int, bufferData *byte, bufferSize int) types.Status {
+	// TODO: implement host emulator set buffer bytes
+	return types.StatusOK
+}
+
 // impl rawhostcall.ProxyWASMHost
 func (h *hostEmulator) ProxyGetHeaderMapValue(mapType types.MapType, keyData *byte,
 	keySize int, returnValueData **byte, returnValueSize *int) types.Status {

--- a/proxytest/proxytest.go
+++ b/proxytest/proxytest.go
@@ -41,7 +41,9 @@ type HostEmulator interface {
 	HttpFilterPutRequestTrailers(contextID uint32, headers [][2]string)
 	HttpFilterPutResponseTrailers(contextID uint32, headers [][2]string)
 	HttpFilterPutRequestBody(contextID uint32, body []byte)
+	HttpFilterGetRequestBody(contextID uint32) []byte
 	HttpFilterPutResponseBody(contextID uint32, body []byte)
+	HttpFilterGetResponseBody(contextID uint32) []byte
 	HttpFilterCompleteHttpStream(contextID uint32)
 	HttpFilterGetCurrentStreamAction(contextID uint32) types.Action
 	HttpFilterGetSentLocalResponse(contextID uint32) *LocalHttpResponse
@@ -117,8 +119,12 @@ func (h *hostEmulator) ProxyGetBufferBytes(bt types.BufferType, start int, maxSi
 }
 
 func (h *hostEmulator) ProxySetBufferBytes(bt types.BufferType, start int, maxSize int, bufferData *byte, bufferSize int) types.Status {
-	// TODO: implement host emulator set buffer bytes
-	return types.StatusOK
+	switch bt {
+	case types.BufferTypeHttpRequestBody, types.BufferTypeHttpResponseBody:
+		return h.httpHostEmulatorProxySetBufferBytes(bt, start, maxSize, bufferData, bufferSize)
+	default:
+		panic("unreachable: maybe a bug in this host emulation or SDK")
+	}
 }
 
 // impl rawhostcall.ProxyWASMHost

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -129,11 +129,10 @@ func GetHttpRequestBody(start, maxSize int) ([]byte, error) {
 }
 
 func SetHttpRequestBody(body []byte) error {
-	if len(body) == 0 {
-		st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpRequestBody, 0, len(body), nil, len(body))
-		return types.StatusToError(st)
+	var bufferData *byte
+	if len(body) != 0 {
+		bufferData = &body[0]
 	}
-	bufferData := &body[0]
 	st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpRequestBody, 0, len(body), bufferData, len(body))
 	return types.StatusToError(st)
 }
@@ -200,11 +199,10 @@ func GetHttpResponseBody(start, maxSize int) ([]byte, error) {
 }
 
 func SetHttpResponseBody(body []byte) error {
-	if len(body) == 0 {
-		st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpRequestBody, 0, len(body), nil, len(body))
-		return types.StatusToError(st)
+	var bufferData *byte
+	if len(body) != 0 {
+		bufferData = &body[0]
 	}
-	bufferData := &body[0]
 	st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpResponseBody, 0, len(body), bufferData, len(body))
 	return types.StatusToError(st)
 }

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -128,6 +128,15 @@ func GetHttpRequestBody(start, maxSize int) ([]byte, error) {
 	return ret, types.StatusToError(st)
 }
 
+func SetHttpRequestBody(body []byte) error {
+	if len(body) == 0 {
+		return types.StatusToError(types.StatusBadArgument)
+	}
+	bufferData := &body[0]
+	st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpRequestBody, 0, len(body), bufferData, len(body))
+	return types.StatusToError(st)
+}
+
 func GetHttpRequestTrailers() ([][2]string, error) {
 	ret, st := getMap(types.MapTypeHttpRequestTrailers)
 	return ret, types.StatusToError(st)
@@ -187,6 +196,15 @@ func AddHttpResponseHeader(key, value string) error {
 func GetHttpResponseBody(start, maxSize int) ([]byte, error) {
 	ret, st := getBuffer(types.BufferTypeHttpResponseBody, start, maxSize)
 	return ret, types.StatusToError(st)
+}
+
+func SetHttpResponseBody(body []byte) error {
+	if len(body) == 0 {
+		return types.StatusToError(types.StatusBadArgument)
+	}
+	bufferData := &body[0]
+	st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpResponseBody, 0, len(body), bufferData, len(body))
+	return types.StatusToError(st)
 }
 
 func GetHttpResponseTrailers() ([][2]string, error) {

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -130,7 +130,8 @@ func GetHttpRequestBody(start, maxSize int) ([]byte, error) {
 
 func SetHttpRequestBody(body []byte) error {
 	if len(body) == 0 {
-		return types.StatusToError(types.StatusBadArgument)
+		st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpRequestBody, 0, len(body), nil, len(body))
+		return types.StatusToError(st)
 	}
 	bufferData := &body[0]
 	st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpRequestBody, 0, len(body), bufferData, len(body))
@@ -200,7 +201,8 @@ func GetHttpResponseBody(start, maxSize int) ([]byte, error) {
 
 func SetHttpResponseBody(body []byte) error {
 	if len(body) == 0 {
-		return types.StatusToError(types.StatusBadArgument)
+		st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpRequestBody, 0, len(body), nil, len(body))
+		return types.StatusToError(st)
 	}
 	bufferData := &body[0]
 	st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpResponseBody, 0, len(body), bufferData, len(body))

--- a/proxywasm/rawhostcall/rawhostcall.go
+++ b/proxywasm/rawhostcall/rawhostcall.go
@@ -66,6 +66,9 @@ func ProxySetHeaderMapPairs(mapType types.MapType, mapData *byte, mapSize int) t
 //export proxy_get_buffer_bytes
 func ProxyGetBufferBytes(bt types.BufferType, start int, maxSize int, returnBufferData **byte, returnBufferSize *int) types.Status
 
+//export proxy_set_buffer_bytes
+func ProxySetBufferBytes(bt types.BufferType, start int, maxSize int, bufferData *byte, bufferSize int) types.Status
+
 //export proxy_continue_stream
 func ProxyContinueStream(streamType types.StreamType) types.Status
 

--- a/proxywasm/rawhostcall/rawhostcall_mock.go
+++ b/proxywasm/rawhostcall/rawhostcall_mock.go
@@ -44,6 +44,7 @@ type ProxyWASMHost interface {
 	ProxyGetHeaderMapPairs(mapType types.MapType, returnValueData **byte, returnValueSize *int) types.Status
 	ProxySetHeaderMapPairs(mapType types.MapType, mapData *byte, mapSize int) types.Status
 	ProxyGetBufferBytes(bt types.BufferType, start int, maxSize int, returnBufferData **byte, returnBufferSize *int) types.Status
+	ProxySetBufferBytes(bt types.BufferType, start int, maxSize int, bufferData *byte, bufferSize int) types.Status
 	ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, headerSize int, bodyData *byte, bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) types.Status
 	ProxySetTickPeriodMilliseconds(period uint32) types.Status
 	ProxyGetCurrentTimeNanoseconds(returnTime *int64) types.Status
@@ -110,6 +111,9 @@ func (d DefaultProxyWAMSHost) ProxySetHeaderMapPairs(mapType types.MapType, mapD
 	return 0
 }
 func (d DefaultProxyWAMSHost) ProxyGetBufferBytes(bt types.BufferType, start int, maxSize int, returnBufferData **byte, returnBufferSize *int) types.Status {
+	return 0
+}
+func (d DefaultProxyWAMSHost) ProxySetBufferBytes(bt types.BufferType, start int, maxSize int, bufferData *byte, bufferSize int) types.Status {
 	return 0
 }
 func (d DefaultProxyWAMSHost) ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, headerSize int, bodyData *byte, bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) types.Status {
@@ -207,6 +211,10 @@ func ProxySetHeaderMapPairs(mapType types.MapType, mapData *byte, mapSize int) t
 
 func ProxyGetBufferBytes(bt types.BufferType, start int, maxSize int, returnBufferData **byte, returnBufferSize *int) types.Status {
 	return currentHost.ProxyGetBufferBytes(bt, start, maxSize, returnBufferData, returnBufferSize)
+}
+
+func ProxySetBufferBytes(bt types.BufferType, start int, maxSize int, bufferData *byte, bufferSize int) types.Status {
+	return currentHost.ProxySetBufferBytes(bt, start, maxSize, bufferData, bufferSize)
 }
 
 func ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, headerSize int, bodyData *byte,


### PR DESCRIPTION
Resolve https://github.com/tetratelabs/proxy-wasm-go-sdk/issues/45

We've tested the `set buffer bytes` function deployed in Istio and it seems to be working as expected.

Filter built tiny go version:
```
tinygo version  
tinygo version 0.16.0-dev darwin/amd64 (using go version go1.15 and LLVM version 10.0.1)
```

Built using:
```
tinygo build -o ./filters/myfilter/filter.wasm -target=wasi -wasm-abi=generic ./myfilter.go
```

Istio version
```
istioctl version                                                                                                                
client version: 1.7.0
control plane version: 1.7.0
data plane version: 1.7.0 (10 proxies)
```

Example usage:
```GOLANG
        body := []byte(`{ "data": "my new body" }`)
	bufferData := &body[0]
	res := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpRequestBody, 0, len(body), bufferData, len(body))
	if res != types.StatusOK {
		// handle error
	}
	err = proxywasm.SetHttpRequestHeader("content-length", fmt.Sprintf("%d", len(body)))
	if err != nil {
		// handle error
	}

```

Envoy filter description:
```YAML
Name:         wasm-myfilter
Namespace:    mycluster
Labels:       app.kubernetes.io/managed-by=Helm
Annotations:  meta.helm.sh/release-name: mycluster-cluster-config
              meta.helm.sh/release-namespace: mycluster
API Version:  networking.istio.io/v1alpha3
Kind:         EnvoyFilter
Metadata:
  Creation Timestamp:  2020-10-09T07:59:52Z
  Generation:          1
  Managed Fields:
    API Version:  networking.istio.io/v1alpha3
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:meta.helm.sh/release-name:
          f:meta.helm.sh/release-namespace:
        f:labels:
          .:
          f:app.kubernetes.io/managed-by:
      f:spec:
        .:
        f:configPatches:
        f:workloadSelector:
          .:
          f:labels:
            .:
            f:wasm_filter_myfilter:
    Manager:         Go-http-client
    Operation:       Update
    Time:            2020-10-09T07:59:52Z
  Resource Version:  2806
  Self Link:         /apis/networking.istio.io/v1alpha3/namespaces/mycluster/envoyfilters/wasm-myfilter
  UID:               fb324c3b-80aa-476a-9ab6-ecb2a5bbdf55
Spec:
  Config Patches:
    Apply To:  HTTP_FILTER
    Match:
      Context:  SIDECAR_INBOUND
      Listener:
        Filter Chain:
          Filter:
            Name:  envoy.http_connection_manager
            Sub Filter:
              Name:   autopseudo_filter
        Port Number:  80
      Proxy:
        Proxy Version:  ^1\.7.*
    Patch:
      Operation:  INSERT_BEFORE
      Value:
        Name:  myfilter_filter
        typed_config:
          @type:     type.googleapis.com/udpa.type.v1.TypedStruct
          type_url:  type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
          Value:
            Config:
              Configuration:
                @type:  type.googleapis.com/google.protobuf.StringValue
                Value:  /gql
              root_id:  myfilter_root_id
              vm_config:
                Code:
                  Local:
                    Filename:  /var/local/lib/wasm-filters/myfilter/filter.wasm
                Runtime:       envoy.wasm.runtime.v8
                vm_id:         myfilter_filter
  Workload Selector:
    Labels:
      wasm_filter_myfilter:  enabled
Events:                       <none>
```