### PR TITLE
use tinygo/tinygo-dev image and add make target for building binaries with docker image

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -32,7 +32,7 @@ jobs:
     name: build examples
     runs-on: ubuntu-latest
     container:
-      image: getenvoy/extension-tinygo-builder:wasi-dev
+      image: tinygo/tinygo-dev:latest # TODO: use the tagged `tinygo/tinygo:0.xx.x` image after the next release
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,22 @@
 
 ISTIO_VERSION ?= 1.7.2
 
-.PHONY: build.example build.examples lint test test.sdk test.e2e
+.PHONY: build.example build.example.docker build.examples build.examples.docker lint test test.sdk test.e2e
 
 build.example:
 	tinygo build -o ./examples/${name}/main.go.wasm -scheduler=none -target=wasi -wasm-abi=generic ./examples/${name}/main.go
 
+build.example.docker:
+	docker run -it -w /tmp/proxy-wasm-go -v $(shell pwd):/tmp/proxy-wasm-go tinygo/tinygo-dev:latest \
+		tinygo build -o /tmp/proxy-wasm-go/examples/${name}/main.go.wasm -scheduler=none -target=wasi \
+		-wasm-abi=generic /tmp/proxy-wasm-go/examples/${name}/main.go
+
 build.examples:
 	find ./examples -type f -name "main.go" | xargs -Ip tinygo build -o p.wasm -scheduler=none -target=wasi -wasm-abi=generic p
+
+build.examples.docker:
+	docker run -it -w /tmp/proxy-wasm-go -v $(shell pwd):/tmp/proxy-wasm-go tinygo/tinygo-dev:latest /bin/bash -c \
+		'find /tmp/proxy-wasm-go/examples/ -type f -name "main.go" | xargs -Ip tinygo build -o p.wasm -scheduler=none -target=wasi -wasm-abi=generic p'
 
 lint:
 	golangci-lint run --build-tags proxytest

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ func (ctx *metricHttpContext) OnHttpRequestHeaders(int, bool) types.Action {
 
 ### requirements
 
-proxy-wasm-go-sdk depends on the latest TinyGo which supports WASI target([tinygo-org/tinygo#1373](https://github.com/tinygo-org/tinygo/pull/1373)).
-In order to install that, simply run (Ubuntu/Debian):
+proxy-wasm-go-sdk depends on TinyGo's latest [dev branch](https://github.com/tinygo-org/tinygo/tree/dev) which supports WASI target([tinygo-org/tinygo#1373](https://github.com/tinygo-org/tinygo/pull/1373))
+and has yet to be tagged.
+
+In order to install that version of TinyGo, simply run (Ubuntu/Debian):
 
 ```shell
 # this corresponds to https://github.com/tinygo-org/tinygo/commit/f50ad3585d084b17f7754f4b3cb0d42661fee036
@@ -44,9 +46,9 @@ wget https://19227-136505169-gh.circle-artifacts.com/0/tmp/tinygo_amd64.deb
 dpkg -i tinygo_amd64.deb
 ```
 
-Alternatively, you can use the pre-built docker container `getenvoy/extention-tingyo-builder:wasi-dev` for any platform.
+Alternatively, you can use the pre-built docker container `tinygo/tinygo-dev:latest` for any platform.
 
-TinyGo's official release of WASI target will come soon, and after that you could
+TinyGo's official tagged release of WASI target will come soon, and after that you could
  just follow https://tinygo.org/getting-started/ to install the requirement on any platform. Stay tuned!
 
 
@@ -63,9 +65,11 @@ TinyGo's official release of WASI target will come soon, and after that you coul
 build:
 
 ```bash
-make build.examples # build all examples
+make build.examples        # build all examples
+make build.examples.docker # in docker
 
-make build.example name=helloworld # build a specific example
+make build.example name=helloworld        # build a specific example
+make build.example.docker name=helloworld # in docker
 ```
 
 run:


### PR DESCRIPTION
changes made:
- use `tinygo/tinygo-dev:latest` image for building examples
    - that corresponds to the dev branch of tinygo
- add make targets for building examples with that docker image 

Signed-off-by: mathetake <takeshi@tetrate.io>

resolve #81 