### PR TITLE
chore: correctly clear context when proxy is done

### DIFF
--- a/proxywasm/abi_lifecycle.go
+++ b/proxywasm/abi_lifecycle.go
@@ -37,7 +37,7 @@ func proxyOnDone(contextID uint32) bool {
 	} else if ctx, ok := currentState.httpStreams[contextID]; ok {
 		currentState.setActiveContextID(contextID)
 		ctx.OnHttpStreamDone()
-		currentState.httpStreams[contextID] = nil
+		delete(currentState.httpStreams, contextID)
 		return true
 	} else if ctx, ok := currentState.rootContexts[contextID]; ok {
 		currentState.setActiveContextID(contextID)

--- a/proxywasm/abi_lifecycle.go
+++ b/proxywasm/abi_lifecycle.go
@@ -31,7 +31,7 @@ func proxyOnContextCreate(contextID uint32, rootContextID uint32) {
 func proxyOnDone(contextID uint32) bool {
 	if ctx, ok := currentState.streams[contextID]; ok {
 		currentState.setActiveContextID(contextID)
-		currentState.streams[contextID] = nil
+		delete(currentState.streams, contextID)
 		ctx.OnStreamDone()
 		return true
 	} else if ctx, ok := currentState.httpStreams[contextID]; ok {

--- a/proxywasm/abi_lifecycle.go
+++ b/proxywasm/abi_lifecycle.go
@@ -42,7 +42,7 @@ func proxyOnDone(contextID uint32) bool {
 	} else if ctx, ok := currentState.rootContexts[contextID]; ok {
 		currentState.setActiveContextID(contextID)
 		response := ctx.context.OnVMDone()
-		currentState.rootContexts[contextID] = nil
+		delete(currentState.rootContexts, contextID)
 		return response
 	} else {
 		panic("invalid context on proxy_on_done")

--- a/proxywasm/abi_lifecycle.go
+++ b/proxywasm/abi_lifecycle.go
@@ -31,15 +31,19 @@ func proxyOnContextCreate(contextID uint32, rootContextID uint32) {
 func proxyOnDone(contextID uint32) bool {
 	if ctx, ok := currentState.streams[contextID]; ok {
 		currentState.setActiveContextID(contextID)
+		currentState.streams[contextID] = nil
 		ctx.OnStreamDone()
 		return true
 	} else if ctx, ok := currentState.httpStreams[contextID]; ok {
 		currentState.setActiveContextID(contextID)
 		ctx.OnHttpStreamDone()
+		currentState.httpStreams[contextID] = nil
 		return true
 	} else if ctx, ok := currentState.rootContexts[contextID]; ok {
 		currentState.setActiveContextID(contextID)
-		return ctx.context.OnVMDone()
+		response := ctx.context.OnVMDone()
+		currentState.rootContexts[contextID] = nil
+		return response
 	} else {
 		panic("invalid context on proxy_on_done")
 	}


### PR DESCRIPTION
The context maps were not cleared on done, which caused the filters to crash after sending a few requests, since they ran out of memory.