### PR TITLE
update upstream envoy on ci

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -49,7 +49,7 @@ jobs:
   e2e-tests-envoy:
     strategy:
       matrix:
-        envoy-image: [ "envoyproxy/envoy-dev:6287f174f72ca6ca841cdac2cf5cc645c95dd754" ] # TODO: add release tagged version
+        envoy-image: [ "envoyproxy/envoy-dev:55538fd04eb4f556aebd2d2e60cc99374e9d73b2" ] # TODO: add release tagged version
     name: e2e tests on examples
     needs: build-examples
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ and has yet to be tagged.
 In order to install that version of TinyGo, simply run (Ubuntu/Debian):
 
 ```shell
-# this corresponds to https://github.com/tinygo-org/tinygo/commit/f50ad3585d084b17f7754f4b3cb0d42661fee036
-wget https://19227-136505169-gh.circle-artifacts.com/0/tmp/tinygo_amd64.deb
+# this is the latest commit as of Oct 29, 2020
+wget https://20372-136505169-gh.circle-artifacts.com/0/tmp/tinygo_amd64.deb
 dpkg -i tinygo_amd64.deb
 ```
 
@@ -57,7 +57,7 @@ TinyGo's official tagged release of WASI target will come soon, and after that y
 | proxy-wasm-go-sdk| proxy-wasm ABI version |istio/proxyv2| Envoy upstream|
 |:-------------:|:-------------:|:-------------:|:-------------:|
 | main |  0.2.0|   v1.17.x |   [55538fd04eb4f556aebd](https://github.com/envoyproxy/envoy/tree/55538fd04eb4f556aebd2d2e60cc99374e9d73b2) |
-| v0.0.9 |  0.2.0|   v1.17.x | [6287f174f72ca6ca841c](https://github.com/envoyproxy/envoy/tree/6287f174f72ca6ca841cdac2cf5cc645c95dd754) |
+| v0.0.10 |  0.2.0|   v1.17.x | [55538fd04eb4f556aebd](https://github.com/envoyproxy/envoy/tree/55538fd04eb4f556aebd2d2e60cc99374e9d73b2) |
 
 
 ## run examples

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ TinyGo's official tagged release of WASI target will come soon, and after that y
  just follow https://tinygo.org/getting-started/ to install the requirement on any platform. Stay tuned!
 
 
-### compatible ABI / Envoy builds
+### compatible ABI / Envoy builds (verified on CI)
 
 | proxy-wasm-go-sdk| proxy-wasm ABI version |istio/proxyv2| Envoy upstream|
 |:-------------:|:-------------:|:-------------:|:-------------:|
-| main |  0.2.0|   v1.17.x | [6287f174f72ca6ca841c](https://github.com/envoyproxy/envoy/tree/6287f174f72ca6ca841cdac2cf5cc645c95dd754) |
+| main |  0.2.0|   v1.17.x |   [55538fd04eb4f556aebd](https://github.com/envoyproxy/envoy/tree/55538fd04eb4f556aebd2d2e60cc99374e9d73b2) |
 | v0.0.9 |  0.2.0|   v1.17.x | [6287f174f72ca6ca841c](https://github.com/envoyproxy/envoy/tree/6287f174f72ca6ca841cdac2cf5cc645c95dd754) |
 
 


### PR DESCRIPTION
ref:  https://github.com/tetratelabs/proxy-wasm-go-sdk/issues/88

Signed-off-by: mathetake <takeshi@tetrate.io>

