### PR TITLE
feat: add GetRootContextByID call

### DIFF
--- a/examples/configuration_from_root/README.md
+++ b/examples/configuration_from_root/README.md
@@ -1,0 +1,10 @@
+## configuration_from_root
+
+This example reads the json string from Envoy's configuration yaml at the startup time
+The child HTTP context then reads the config from its corresponding root context.
+
+```
+wasm log my_root_id: plugin config: {
+  "name": "plugin configuration"
+}
+```

--- a/examples/configuration_from_root/envoy.yaml
+++ b/examples/configuration_from_root/envoy.yaml
@@ -1,0 +1,89 @@
+static_resources:
+  listeners:
+    - name: main
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 18000
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: web_service
+                http_filters:
+                  - name: envoy.filters.http.wasm
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+                      config:
+                        configuration:
+                          "@type": type.googleapis.com/google.protobuf.StringValue
+                          value: |
+                            {
+                              "name": "plugin configuration"
+                            }
+                        name: "my_plugin"
+                        root_id: "my_root_id"
+                        vm_config:
+                          vm_id: "my_vm_id"
+                          runtime: envoy.wasm.runtime.v8
+                          code:
+                            local:
+                              filename: "./examples/configuration_from_root/main.go.wasm"
+                          allow_precompiled: true
+                  - name: envoy.filters.http.router
+
+    - name: staticreply
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 8099
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          direct_response:
+                            status: 200
+                            body:
+                              inline_string: "example body\n"
+                http_filters:
+                  - name: envoy.router
+                    config: {}
+
+  clusters:
+    - name: web_service
+      connect_timeout: 0.25s
+      type: static
+      lb_policy: round_robin
+      hosts:
+        - socket_address:
+            address: 127.0.0.1
+            port_value: 8099
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/configuration_from_root/main.go
+++ b/examples/configuration_from_root/main.go
@@ -1,0 +1,72 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+)
+
+func main() {
+	proxywasm.SetNewRootContext(newRootContext)
+	proxywasm.SetNewHttpContext(newHttpContext)
+}
+
+type rootContext struct {
+	// you must embed the default context so that you need not to reimplement all the methods by yourself
+	proxywasm.DefaultRootContext
+
+	config []byte
+}
+
+func newRootContext(contextID uint32) proxywasm.RootContext {
+	return &rootContext{}
+}
+
+func (ctx *rootContext) OnPluginStart(pluginConfigurationSize int) bool {
+	data, err := proxywasm.GetPluginConfiguration(pluginConfigurationSize)
+	if err != nil {
+		proxywasm.LogCriticalf("error reading plugin configuration: %v", err)
+	}
+
+	ctx.config = data
+	return true
+}
+
+type httpContext struct {
+	proxywasm.DefaultHttpContext
+
+	config []byte
+}
+
+func newHttpContext(rootContextID, contextID uint32) proxywasm.HttpContext {
+	ctx := &httpContext{}
+
+	rootCtx, err := proxywasm.GetRootContextByID(rootContextID)
+	if err != nil {
+		proxywasm.LogErrorf("unable to get root context: %v", err)
+
+		return ctx
+	}
+
+	exampleRootCtx, ok := rootCtx.(*rootContext)
+	if !ok {
+		proxywasm.LogError("could not cast root context")
+	}
+
+	ctx.config = exampleRootCtx.config
+
+	proxywasm.LogInfof("plugin config: %s\n", string(ctx.config))
+	return ctx
+}

--- a/examples/configuration_from_root/main_test.go
+++ b/examples/configuration_from_root/main_test.go
@@ -1,0 +1,50 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxytest"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func TestContext_OnPluginStart(t *testing.T) {
+	pluginConfigData := `{"name": "tinygo plugin configuration"}`
+
+	opt := proxytest.NewEmulatorOption().
+		WithNewRootContext(newRootContext).
+		WithNewHttpContext(newHttpContext).
+		WithPluginConfiguration([]byte(pluginConfigData))
+	host := proxytest.NewHostEmulator(opt)
+	defer host.Done() // release the emulation lock so that other test cases can insert their own host emulation
+
+	host.StartPlugin() // invoke OnPluginStart
+
+	host.HttpFilterInitContext()
+
+	errLogs := host.GetLogs(types.LogLevelError)
+	require.Len(t, errLogs, 0)
+
+	logs := host.GetLogs(types.LogLevelInfo)
+	require.Greater(t, len(logs), 0)
+	msg := logs[len(logs)-1]
+	assert.True(t, strings.Contains(msg, pluginConfigData))
+}

--- a/proxywasm/vmstate.go
+++ b/proxywasm/vmstate.go
@@ -14,6 +14,11 @@
 
 package proxywasm
 
+import (
+	"errors"
+	"fmt"
+)
+
 type (
 	HttpCalloutCallBack = func(numHeaders, bodySize, numTrailers int)
 
@@ -55,6 +60,16 @@ func SetNewHttpContext(f func(rootContextID, contextID uint32) HttpContext) {
 
 func SetNewStreamContext(f func(rootContextID, contextID uint32) StreamContext) {
 	currentState.newStreamContext = f
+}
+
+var ErrorRootContextNotFound = errors.New("root context not found")
+
+func GetRootContextByID(rootContextID uint32) (RootContext, error) {
+	rootContextState, ok := currentState.rootContexts[rootContextID]
+	if !ok {
+		return nil, fmt.Errorf("%w: %d", ErrorRootContextNotFound, rootContextID)
+	}
+	return rootContextState.context, nil
 }
 
 //go:inline


### PR DESCRIPTION
I would like to add this GetRootContextByID call, so that configuration stored in the root context can be read by the child context.