### PR TITLE
fix: add body to ProxyHttpCall return value

### DIFF
--- a/proxytest/root.go
+++ b/proxytest/root.go
@@ -252,7 +252,9 @@ func (r *rootHostEmulator) ProxyHttpCall(upstreamData *byte, upstreamSize int, h
 		Upstream:  upstream,
 		Headers:   headers,
 		Trailers:  trailers,
+		Body: []byte(body),
 	})
+
 	*calloutIDPtr = calloutID
 	return types.StatusOK
 }


### PR DESCRIPTION
As discussed in: https://github.com/tetratelabs/proxy-wasm-go-sdk/issues/95

This allows users to check the body for outgoing http requests in tests.

resolves  https://github.com/tetratelabs/proxy-wasm-go-sdk/issues/95