### PR TITLE
Update for TinyGo 0.16.0 release

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -32,7 +32,7 @@ jobs:
     name: build examples
     runs-on: ubuntu-latest
     container:
-      image: tinygo/tinygo:0.16.0
+      image: tinygo/tinygo:latest
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -32,7 +32,7 @@ jobs:
     name: build examples
     runs-on: ubuntu-latest
     container:
-      image: tinygo/tinygo-dev:latest # TODO: use the tagged `tinygo/tinygo:0.xx.x` image after the next release
+      image: tinygo/tinygo:0.16.0
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: build examples
-        run: make build.examples
+        run: find ./examples -type f -name "main.go" | xargs -Ip tinygo build -o p.wasm -scheduler=none -target=wasi -wasm-abi=generic p
 
       - name: upload wasm-binaries
         uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build.examples:
 	find ./examples -type f -name "main.go" | xargs -Ip tinygo build -o p.wasm -scheduler=none -target=wasi -wasm-abi=generic p
 
 build.examples.docker:
-	docker run -it -w /tmp/proxy-wasm-go -v $(shell pwd):/tmp/proxy-wasm-go tinygo/tinygo-dev:latest /bin/bash -c \
+	docker run -it -w /tmp/proxy-wasm-go -v $(shell pwd):/tmp/proxy-wasm-go tinygo/tinygo:latest /bin/bash -c \
 		'find /tmp/proxy-wasm-go/examples/ -type f -name "main.go" | xargs -Ip tinygo build -o p.wasm -scheduler=none -target=wasi -wasm-abi=generic p'
 
 lint:

--- a/README.md
+++ b/README.md
@@ -35,22 +35,10 @@ func (ctx *metricHttpContext) OnHttpRequestHeaders(int, bool) types.Action {
 
 ### requirements
 
-proxy-wasm-go-sdk depends on TinyGo's latest [dev branch](https://github.com/tinygo-org/tinygo/tree/dev) which supports WASI target([tinygo-org/tinygo#1373](https://github.com/tinygo-org/tinygo/pull/1373))
-and has yet to be tagged.
+proxy-wasm-go-sdk depends on TinyGo's [WASI](https://github.com/WebAssembly/WASI) (WebAssembly System Interface) target
+which is introduced in [v0.16.0](https://github.com/tinygo-org/tinygo/releases/tag/v0.16.0).
 
-In order to install that version of TinyGo, simply run (Ubuntu/Debian):
-
-```shell
-# this is the latest commit as of Oct 29, 2020
-wget https://20372-136505169-gh.circle-artifacts.com/0/tmp/tinygo_amd64.deb
-dpkg -i tinygo_amd64.deb
-```
-
-Alternatively, you can use the pre-built docker container `tinygo/tinygo-dev:latest` for any platform.
-
-TinyGo's official tagged release of WASI target will come soon, and after that you could
- just follow https://tinygo.org/getting-started/ to install the requirement on any platform. Stay tuned!
-
+Please follow the official instruction [here](https://tinygo.org/getting-started/).
 
 ### compatible ABI / Envoy builds (verified on CI)
 


### PR DESCRIPTION
the container is yet to be pushed to dockerhub

Signed-off-by: mathetake <takeshi@tetrate.io>