### PR TITLE
Istio 1.8.1

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -78,7 +78,7 @@ jobs:
   e2e-tests-istio:
     strategy:
       matrix:
-        istio-version: [ 1.7.0, 1.7.1, 1.7.2, 1.7.3, 1.8.0 ]
+        istio-version: [ 1.8.1 ]
     name: e2e tests on examples
     needs: build-examples
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -51,7 +51,7 @@ jobs:
   e2e-tests-envoy:
     strategy:
       matrix:
-        envoy-image: [ "envoyproxy/envoy-dev:6ca4644073da6d9930ba45d90d57d8c9b2062962" ] # TODO: add release tagged version
+        envoy-image: [ "envoyproxy/envoy-dev:5932dfd1f6b80eda9f56415ceff056a15a699c5e" ] # TODO: add release tagged version
     name: e2e tests on examples
     needs: build-examples
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Please follow the official instruction [here](https://tinygo.org/getting-started
 
 | proxy-wasm-go-sdk| proxy-wasm ABI version |istio/proxyv2| Envoy upstream|
 |:-------------:|:-------------:|:-------------:|:-------------:|
-| main |  0.2.0|   v1.17.x,  v1.18.0 | [6ca4644073da6d9930ba](https://github.com/envoyproxy/envoy/tree/6ca4644073da6d9930ba45d90d57d8c9b2062962) |
-| v0.0.12 |  0.2.0|  v1.17.x, v1.18.0 |[6ca4644073da6d9930ba](https://github.com/envoyproxy/envoy/tree/6ca4644073da6d9930ba45d90d57d8c9b2062962) 
+| main |  0.2.0|   v1.8.1 | [5932dfd1f6b80eda9f56](https://github.com/envoyproxy/envoy/tree/5932dfd1f6b80eda9f56415ceff056a15a699c5e) |
+| v0.0.12 |  0.2.0|  v1.7.x, v1.8.0 |[6ca4644073da6d9930ba](https://github.com/envoyproxy/envoy/tree/6ca4644073da6d9930ba45d90d57d8c9b2062962) 
 
 
 ## run examples
@@ -86,7 +86,6 @@ make test.e2e.single name=helloworld # run e2e tests
         2. TinyGo does not implement all of reflect package([examples](https://github.com/tinygo-org/tinygo/blob/v0.14.1/src/reflect/value.go#L299-L305)).
         3. [proxy-wasm-cpp-host](https://github.com/proxy-wasm/proxy-wasm-cpp-host) has not supported some of WASI APIs yet 
         (see the [supported functions](https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/master/include/proxy-wasm/exports.h#L134-L147)).
-         For example, `clock_time_get` is not implemented, and therefore we cannot use `time.Now` function.
     - These issues will be mitigated as TinyGo and proxy-wasm-cpp-host evolve.
 - There's performance overhead of using Go/TinyGo due to GC
     - `runtime.GC` is called whenever the heap runs out (see [1](https://tinygo.org/lang-support/#garbage-collection),

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"math/rand"
+	"time"
 
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 )
@@ -38,7 +39,7 @@ func newHelloWorld(contextID uint32) proxywasm.RootContext {
 
 // override
 func (ctx *helloWorld) OnVMStart(vmConfigurationSize int) bool {
-	rand.Seed(proxywasm.GetCurrentTime())
+	rand.Seed(time.Now().UnixNano())
 
 	proxywasm.LogInfo("proxy_on_vm_start from Go!")
 	if err := proxywasm.SetTickPeriodMilliSeconds(tickMilliseconds); err != nil {
@@ -50,6 +51,6 @@ func (ctx *helloWorld) OnVMStart(vmConfigurationSize int) bool {
 
 // override
 func (ctx *helloWorld) OnTick() {
-	t := proxywasm.GetCurrentTime()
+	t := time.Now().UnixNano()
 	proxywasm.LogInfof("It's %d: random value: %d", t, rand.Uint64())
 }

--- a/proxytest/proxytest.go
+++ b/proxytest/proxytest.go
@@ -3,7 +3,6 @@ package proxytest
 import (
 	"log"
 	"sync"
-	"time"
 
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/rawhostcall"
@@ -161,12 +160,6 @@ func (h *hostEmulator) ProxyGetHeaderMapPairs(mapType types.MapType, returnValue
 	default:
 		panic("unreachable: maybe a bug in this host emulation or SDK")
 	}
-}
-
-// impl rawhostcall.ProxyWASMHost
-func (h *hostEmulator) ProxyGetCurrentTimeNanoseconds(returnTime *int64) types.Status {
-	*returnTime = time.Now().UnixNano()
-	return types.StatusOK
 }
 
 // impl rawhostcall.ProxyWASMHost

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -44,12 +44,6 @@ func SetTickPeriodMilliSeconds(millSec uint32) error {
 	return types.StatusToError(rawhostcall.ProxySetTickPeriodMilliseconds(millSec))
 }
 
-func GetCurrentTime() int64 {
-	var t int64
-	rawhostcall.ProxyGetCurrentTimeNanoseconds(&t)
-	return t
-}
-
 func DispatchHttpCall(upstream string,
 	headers [][2]string, body string, trailers [][2]string,
 	timeoutMillisecond uint32, callBack HttpCalloutCallBack) (calloutID uint32, err error) {

--- a/proxywasm/rawhostcall/rawhostcall.go
+++ b/proxywasm/rawhostcall/rawhostcall.go
@@ -83,9 +83,6 @@ func ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, heade
 //export proxy_set_tick_period_milliseconds
 func ProxySetTickPeriodMilliseconds(period uint32) types.Status
 
-//export proxy_get_current_time_nanoseconds
-func ProxyGetCurrentTimeNanoseconds(returnTime *int64) types.Status
-
 //export proxy_set_effective_context
 func ProxySetEffectiveContext(contextID uint32) types.Status
 

--- a/proxywasm/rawhostcall/rawhostcall_mock.go
+++ b/proxywasm/rawhostcall/rawhostcall_mock.go
@@ -47,7 +47,6 @@ type ProxyWASMHost interface {
 	ProxySetBufferBytes(bt types.BufferType, start int, maxSize int, bufferData *byte, bufferSize int) types.Status
 	ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, headerSize int, bodyData *byte, bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) types.Status
 	ProxySetTickPeriodMilliseconds(period uint32) types.Status
-	ProxyGetCurrentTimeNanoseconds(returnTime *int64) types.Status
 	ProxySetEffectiveContext(contextID uint32) types.Status
 	ProxyDone() types.Status
 	ProxyDefineMetric(metricType types.MetricType, metricNameData *byte, metricNameSize int, returnMetricIDPtr *uint32) types.Status
@@ -120,11 +119,8 @@ func (d DefaultProxyWAMSHost) ProxyHttpCall(upstreamData *byte, upstreamSize int
 	return 0
 }
 func (d DefaultProxyWAMSHost) ProxySetTickPeriodMilliseconds(period uint32) types.Status { return 0 }
-func (d DefaultProxyWAMSHost) ProxyGetCurrentTimeNanoseconds(returnTime *int64) types.Status {
-	return 0
-}
-func (d DefaultProxyWAMSHost) ProxySetEffectiveContext(contextID uint32) types.Status { return 0 }
-func (d DefaultProxyWAMSHost) ProxyDone() types.Status                                { return 0 }
+func (d DefaultProxyWAMSHost) ProxySetEffectiveContext(contextID uint32) types.Status    { return 0 }
+func (d DefaultProxyWAMSHost) ProxyDone() types.Status                                   { return 0 }
 func (d DefaultProxyWAMSHost) ProxyDefineMetric(metricType types.MetricType, metricNameData *byte, metricNameSize int, returnMetricIDPtr *uint32) types.Status {
 	return 0
 }
@@ -225,10 +221,6 @@ func ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, heade
 
 func ProxySetTickPeriodMilliseconds(period uint32) types.Status {
 	return currentHost.ProxySetTickPeriodMilliseconds(period)
-}
-
-func ProxyGetCurrentTimeNanoseconds(returnTime *int64) types.Status {
-	return currentHost.ProxyGetCurrentTimeNanoseconds(returnTime)
 }
 
 func ProxySetEffectiveContext(contextID uint32) types.Status {


### PR DESCRIPTION
Delete proxy_get_current_time_nanoseconds since time.Now is now available as of istio 1.8.1 and already in Envoy's upstream

Signed-off-by: mathetake <takeshi@tetrate.io>