### PR TITLE
Have NewStreamContext and NewHttpContext in RootContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Please follow the official instruction [here](https://tinygo.org/getting-started
 | proxy-wasm-go-sdk| proxy-wasm ABI version |istio/proxyv2| Envoy upstream|
 |:-------------:|:-------------:|:-------------:|:-------------:|
 | main |  0.2.0|   v1.8.x | v1.17.x |
+| v0.0.15 |  0.2.0|   v1.8.x | v1.17.x |
 | v0.0.14 |  0.2.0|   v1.8.1 | v1.17.0 |
-| v0.0.13 |  0.2.0|   v1.8.1 | [5932dfd1f6b80eda9f56](https://github.com/envoyproxy/envoy/tree/5932dfd1f6b80eda9f56415ceff056a15a699c5e) |
 
 
 ## run examples

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Please follow the official instruction [here](https://tinygo.org/getting-started
 | proxy-wasm-go-sdk| proxy-wasm ABI version |istio/proxyv2| Envoy upstream|
 |:-------------:|:-------------:|:-------------:|:-------------:|
 | main |  0.2.0|   v1.8.x | v1.17.x |
-| v0.0.15 |  0.2.0|   v1.8.x | v1.17.x |
 | v0.0.14 |  0.2.0|   v1.8.1 | v1.17.0 |
+| v0.0.13 |  0.2.0|   v1.8.1 | [5932dfd1f6b80eda9f56](https://github.com/envoyproxy/envoy/tree/5932dfd1f6b80eda9f56415ceff056a15a699c5e) |
 
 
 ## run examples

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -299,12 +299,12 @@ func sharedData(t *testing.T, ps envoyPorts, stdErr *bytes.Buffer) {
 
 func sharedQueue(t *testing.T, ps envoyPorts, stdErr *bytes.Buffer) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d", ps.endpoint), nil)
-	require.NoError(t, err, stdErr.String())
+	require.NoError(t, err)
 
 	count := 10
 	for i := 0; i < count; i++ {
 		r, err := http.DefaultClient.Do(req)
-		require.NoError(t, err, stdErr.String())
+		require.NoError(t, err)
 		r.Body.Close()
 	}
 

--- a/examples/configuration_from_root/main.go
+++ b/examples/configuration_from_root/main.go
@@ -20,13 +20,11 @@ import (
 
 func main() {
 	proxywasm.SetNewRootContext(newRootContext)
-	proxywasm.SetNewHttpContext(newHttpContext)
 }
 
 type rootContext struct {
 	// you must embed the default context so that you need not to reimplement all the methods by yourself
 	proxywasm.DefaultRootContext
-
 	config []byte
 }
 
@@ -44,29 +42,14 @@ func (ctx *rootContext) OnPluginStart(pluginConfigurationSize int) bool {
 	return true
 }
 
+func (ctx *rootContext) NewHttpContext(contextID uint32) proxywasm.HttpContext {
+	ret := &httpContext{config: ctx.config}
+	proxywasm.LogInfof("read plugin config from root context: %s\n", string(ret.config))
+	return ret
+}
+
 type httpContext struct {
 	proxywasm.DefaultHttpContext
 
 	config []byte
-}
-
-func newHttpContext(rootContextID, contextID uint32) proxywasm.HttpContext {
-	ctx := &httpContext{}
-
-	rootCtx, err := proxywasm.GetRootContextByID(rootContextID)
-	if err != nil {
-		proxywasm.LogErrorf("unable to get root context: %v", err)
-
-		return ctx
-	}
-
-	exampleRootCtx, ok := rootCtx.(*rootContext)
-	if !ok {
-		proxywasm.LogError("could not cast root context")
-	}
-
-	ctx.config = exampleRootCtx.config
-
-	proxywasm.LogInfof("plugin config from root context: %s\n", string(ctx.config))
-	return ctx
 }

--- a/examples/configuration_from_root/main_test.go
+++ b/examples/configuration_from_root/main_test.go
@@ -31,7 +31,6 @@ func TestContext_OnPluginStart(t *testing.T) {
 
 	opt := proxytest.NewEmulatorOption().
 		WithNewRootContext(newRootContext).
-		WithNewHttpContext(newHttpContext).
 		WithPluginConfiguration([]byte(pluginConfigData))
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done() // release the emulation lock so that other test cases can insert their own host emulation

--- a/examples/http_auth_random/main.go
+++ b/examples/http_auth_random/main.go
@@ -24,17 +24,23 @@ import (
 const clusterName = "httpbin"
 
 func main() {
-	proxywasm.SetNewHttpContext(newContext)
+	proxywasm.SetNewRootContext(newRootContext)
+}
+
+type rootContext struct {
+	proxywasm.DefaultRootContext
+}
+
+func newRootContext(uint32) proxywasm.RootContext { return &rootContext{} }
+
+func (*rootContext) NewHttpContext(contextID uint32) proxywasm.HttpContext {
+	return &httpAuthRandom{contextID: contextID}
 }
 
 type httpAuthRandom struct {
 	// you must embed the default context so that you need not to reimplement all the methods by yourself
 	proxywasm.DefaultHttpContext
 	contextID uint32
-}
-
-func newContext(rootContextID, contextID uint32) proxywasm.HttpContext {
-	return &httpAuthRandom{contextID: contextID}
 }
 
 // override default

--- a/examples/http_auth_random/main_test.go
+++ b/examples/http_auth_random/main_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestHttpAuthRandom_OnHttpRequestHeaders(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewHttpContext(newContext)
+		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done()
 
@@ -35,7 +35,7 @@ func TestHttpAuthRandom_OnHttpRequestHeaders(t *testing.T) {
 
 func TestHttpAuthRandom_OnHttpCallResponse(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewHttpContext(newContext)
+		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done()
 

--- a/examples/http_body/main.go
+++ b/examples/http_body/main.go
@@ -20,17 +20,23 @@ import (
 )
 
 func main() {
-	proxywasm.SetNewHttpContext(newContext)
+	proxywasm.SetNewRootContext(newContext)
+}
+
+type rootContext struct {
+	proxywasm.DefaultRootContext
+}
+
+func newContext(uint32) proxywasm.RootContext { return &rootContext{} }
+
+func (*rootContext) NewHttpContext(contextID uint32) proxywasm.HttpContext {
+	return &httpBody{contextID: contextID}
 }
 
 type httpBody struct {
 	// you must embed the default context so that you need not to reimplement all the methods by yourself
 	proxywasm.DefaultHttpContext
 	contextID uint32
-}
-
-func newContext(rootContextID, contextID uint32) proxywasm.HttpContext {
-	return &httpBody{contextID: contextID}
 }
 
 // override

--- a/examples/http_body/main_test.go
+++ b/examples/http_body/main_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestHttpBody_OnHttpRequestBody(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewHttpContext(newContext)
+		WithNewRootContext(newContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done()
 

--- a/examples/http_headers/main.go
+++ b/examples/http_headers/main.go
@@ -20,17 +20,23 @@ import (
 )
 
 func main() {
-	proxywasm.SetNewHttpContext(newContext)
+	proxywasm.SetNewRootContext(newRootContext)
+}
+
+type rootContext struct {
+	proxywasm.DefaultRootContext
+}
+
+func newRootContext(uint32) proxywasm.RootContext { return &rootContext{} }
+
+func (*rootContext) NewHttpContext(contextID uint32) proxywasm.HttpContext {
+	return &httpHeaders{contextID: contextID}
 }
 
 type httpHeaders struct {
 	// you must embed the default context so that you need not to reimplement all the methods by yourself
 	proxywasm.DefaultHttpContext
 	contextID uint32
-}
-
-func newContext(rootContextID, contextID uint32) proxywasm.HttpContext {
-	return &httpHeaders{contextID: contextID}
 }
 
 // override

--- a/examples/http_headers/main_test.go
+++ b/examples/http_headers/main_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestHttpHeaders_OnHttpRequestHeaders(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewHttpContext(newContext)
+		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done()
 	id := host.HttpFilterInitContext()
@@ -33,7 +33,7 @@ func TestHttpHeaders_OnHttpRequestHeaders(t *testing.T) {
 
 func TestHttpHeaders_OnHttpResponseHeaders(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewHttpContext(newContext)
+		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done()
 	id := host.HttpFilterInitContext()

--- a/examples/metrics/main.go
+++ b/examples/metrics/main.go
@@ -21,7 +21,6 @@ import (
 
 func main() {
 	proxywasm.SetNewRootContext(newRootContext)
-	proxywasm.SetNewHttpContext(newHttpContext)
 }
 
 var counter proxywasm.MetricCounter
@@ -43,13 +42,13 @@ func (ctx *metricRootContext) OnVMStart(vmConfigurationSize int) bool {
 	return true
 }
 
+func (*metricRootContext) NewHttpContext(contextID uint32) proxywasm.HttpContext {
+	return &metricHttpContext{}
+}
+
 type metricHttpContext struct {
 	// you must embed the default context so that you need not to reimplement all the methods by yourself
 	proxywasm.DefaultHttpContext
-}
-
-func newHttpContext(uint32, uint32) proxywasm.HttpContext {
-	return &metricHttpContext{}
 }
 
 // override

--- a/examples/metrics/main_test.go
+++ b/examples/metrics/main_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestMetric(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewHttpContext(newHttpContext).
 		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done() // release the host emulation lock so that other test cases can insert their own host emulation

--- a/examples/network/main.go
+++ b/examples/network/main.go
@@ -26,7 +26,10 @@ var (
 
 func main() {
 	proxywasm.SetNewRootContext(newRootContext)
-	proxywasm.SetNewStreamContext(newNetworkContext)
+}
+
+func newRootContext(contextID uint32) proxywasm.RootContext {
+	return &rootContext{}
 }
 
 type rootContext struct {
@@ -34,22 +37,18 @@ type rootContext struct {
 	proxywasm.DefaultRootContext
 }
 
-func newRootContext(contextID uint32) proxywasm.RootContext {
-	return &rootContext{}
-}
-
 func (ctx *rootContext) OnVMStart(vmConfigurationSize int) bool {
 	counter = proxywasm.DefineCounterMetric(connectionCounterName)
 	return true
 }
 
+func (ctx *rootContext) NewStreamContext(contextID uint32) proxywasm.StreamContext {
+	return &networkContext{}
+}
+
 type networkContext struct {
 	// you must embed the default context so that you need not to reimplement all the methods by yourself
 	proxywasm.DefaultStreamContext
-}
-
-func newNetworkContext(rootContextID, contextID uint32) proxywasm.StreamContext {
-	return &networkContext{}
 }
 
 func (ctx *networkContext) OnNewConnection() types.Action {

--- a/examples/network/main_test.go
+++ b/examples/network/main_test.go
@@ -26,7 +26,6 @@ import (
 
 func TestNetwork_OnNewConnection(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewStreamContext(newNetworkContext).
 		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done() // release the host emulation lock so that other test cases can insert their own host emulation
@@ -41,7 +40,6 @@ func TestNetwork_OnNewConnection(t *testing.T) {
 
 func TestNetwork_OnDownstreamClose(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewStreamContext(newNetworkContext).
 		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done() // release the host emulation lock so that other test cases can insert their own host emulation
@@ -56,7 +54,6 @@ func TestNetwork_OnDownstreamClose(t *testing.T) {
 
 func TestNetwork_OnDownstreamData(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewStreamContext(newNetworkContext).
 		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done() // release the host emulation lock so that other test cases can insert their own host emulation
@@ -73,7 +70,6 @@ func TestNetwork_OnDownstreamData(t *testing.T) {
 
 func TestNetwork_OnUpstreamData(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewStreamContext(newNetworkContext).
 		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done() // release the host emulation lock so that other test cases can insert their own host emulation
@@ -90,7 +86,6 @@ func TestNetwork_OnUpstreamData(t *testing.T) {
 
 func TestNetwork_counter(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewStreamContext(newNetworkContext).
 		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done() // release the host emulation lock so that other test cases can insert their own host emulation

--- a/examples/shared_data/main.go
+++ b/examples/shared_data/main.go
@@ -21,7 +21,6 @@ import (
 
 func main() {
 	proxywasm.SetNewRootContext(newRootContext)
-	proxywasm.SetNewHttpContext(newHttpContext)
 }
 
 type (
@@ -40,10 +39,6 @@ func newRootContext(contextID uint32) proxywasm.RootContext {
 	return &sharedDataRootContext{}
 }
 
-func newHttpContext(rootContextID, contextID uint32) proxywasm.HttpContext {
-	return &sharedDataHttpContext{}
-}
-
 const sharedDataKey = "shared_data_key"
 
 // override
@@ -52,6 +47,11 @@ func (ctx *sharedDataRootContext) OnVMStart(vmConfigurationSize int) bool {
 		proxywasm.LogWarnf("error setting shared data on OnVMStart: %v", err)
 	}
 	return true
+}
+
+// override
+func (*sharedDataRootContext) NewHttpContext(contextID uint32) proxywasm.HttpContext {
+	return &sharedDataHttpContext{}
 }
 
 // override

--- a/examples/shared_data/main_test.go
+++ b/examples/shared_data/main_test.go
@@ -26,7 +26,6 @@ import (
 
 func TestData(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewHttpContext(newHttpContext).
 		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done() // release the host emulation lock so that other test cases can insert their own host emulation

--- a/examples/shared_queue/main.go
+++ b/examples/shared_queue/main.go
@@ -26,7 +26,6 @@ const (
 
 func main() {
 	proxywasm.SetNewRootContext(newRootContext)
-	proxywasm.SetNewHttpContext(newHttpContext)
 }
 
 type queueRootContext struct {
@@ -70,13 +69,14 @@ func (ctx *queueRootContext) OnTick() {
 	}
 }
 
+// override
+func (*queueRootContext) NewHttpContext(contextID uint32) proxywasm.HttpContext {
+	return &queueHttpContext{}
+}
+
 type queueHttpContext struct {
 	// you must embed the default context so that you need not to reimplement all the methods by yourself
 	proxywasm.DefaultHttpContext
-}
-
-func newHttpContext(rootContextID, contextID uint32) proxywasm.HttpContext {
-	return &queueHttpContext{}
 }
 
 // override

--- a/examples/shared_queue/main_test.go
+++ b/examples/shared_queue/main_test.go
@@ -27,7 +27,6 @@ import (
 
 func TestQueue(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
-		WithNewHttpContext(newHttpContext).
 		WithNewRootContext(newRootContext)
 	host := proxytest.NewHostEmulator(opt)
 	defer host.Done() // release the host emulation lock so that other test cases can insert their own host emulation

--- a/proxytest/option.go
+++ b/proxytest/option.go
@@ -19,8 +19,6 @@ import "github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 type EmulatorOption struct {
 	pluginConfiguration, vmConfiguration []byte
 	newRootContext                       func(uint32) proxywasm.RootContext
-	newStreamContext                     func(uint32, uint32) proxywasm.StreamContext
-	newHttpContext                       func(uint32, uint32) proxywasm.HttpContext
 }
 
 func NewEmulatorOption() *EmulatorOption {
@@ -29,16 +27,6 @@ func NewEmulatorOption() *EmulatorOption {
 
 func (o *EmulatorOption) WithNewRootContext(f func(uint32) proxywasm.RootContext) *EmulatorOption {
 	o.newRootContext = f
-	return o
-}
-
-func (o *EmulatorOption) WithNewHttpContext(f func(uint32, uint32) proxywasm.HttpContext) *EmulatorOption {
-	o.newHttpContext = f
-	return o
-}
-
-func (o *EmulatorOption) WithNewStreamContext(f func(uint32, uint32) proxywasm.StreamContext) *EmulatorOption {
-	o.newStreamContext = f
 	return o
 }
 

--- a/proxytest/proxytest.go
+++ b/proxytest/proxytest.go
@@ -102,8 +102,6 @@ func NewHostEmulator(opt *EmulatorOption) HostEmulator {
 
 	// set up state
 	proxywasm.SetNewRootContext(opt.newRootContext)
-	proxywasm.SetNewStreamContext(opt.newStreamContext)
-	proxywasm.SetNewHttpContext(opt.newHttpContext)
 
 	// create root context: TODO: support multiple root contexts
 	proxywasm.ProxyOnContextCreate(RootContextID, 0)

--- a/proxywasm/abi_lifecycle.go
+++ b/proxywasm/abi_lifecycle.go
@@ -18,10 +18,8 @@ package proxywasm
 func proxyOnContextCreate(contextID uint32, rootContextID uint32) {
 	if rootContextID == 0 {
 		currentState.createRootContext(contextID)
-	} else if currentState.newHttpContext != nil {
-		currentState.createHttpContext(contextID, rootContextID)
-	} else if currentState.newStreamContext != nil {
-		currentState.createStreamContext(contextID, rootContextID)
+	} else if currentState.createHttpContext(contextID, rootContextID) {
+	} else if currentState.createStreamContext(contextID, rootContextID) {
 	} else {
 		panic("invalid context id on proxy_on_context_create")
 	}

--- a/proxywasm/context.go
+++ b/proxywasm/context.go
@@ -25,6 +25,10 @@ type RootContext interface {
 	OnPluginStart(pluginConfigurationSize int) bool
 	OnVMDone() bool
 	OnLog()
+
+	// Child context factories
+	NewStreamContext(contextID uint32) StreamContext
+	NewHttpContext(contextID uint32) HttpContext
 }
 
 type StreamContext interface {
@@ -61,12 +65,14 @@ var (
 )
 
 // impl RootContext
-func (*DefaultRootContext) OnQueueReady(uint32)    {}
-func (*DefaultRootContext) OnTick()                {}
-func (*DefaultRootContext) OnVMStart(int) bool     { return true }
-func (*DefaultRootContext) OnPluginStart(int) bool { return true }
-func (*DefaultRootContext) OnVMDone() bool         { return true }
-func (*DefaultRootContext) OnLog()                 {}
+func (*DefaultRootContext) OnQueueReady(uint32)                   {}
+func (*DefaultRootContext) OnTick()                               {}
+func (*DefaultRootContext) OnVMStart(int) bool                    { return true }
+func (*DefaultRootContext) OnPluginStart(int) bool                { return true }
+func (*DefaultRootContext) OnVMDone() bool                        { return true }
+func (*DefaultRootContext) OnLog()                                {}
+func (*DefaultRootContext) NewStreamContext(uint32) StreamContext { return nil }
+func (*DefaultRootContext) NewHttpContext(uint32) HttpContext     { return nil }
 
 // impl StreamContext
 func (*DefaultStreamContext) OnDownstreamData(int, bool) types.Action { return types.ActionContinue }

--- a/proxywasm/vmstate.go
+++ b/proxywasm/vmstate.go
@@ -96,7 +96,7 @@ func (s *state) createStreamContext(contextID uint32, rootContextID uint32) bool
 
 	ctx := root.context.NewStreamContext(contextID)
 	if ctx == nil {
-		// NewHttpContext is not defined by user
+		// NewStreamContext is not defined by the user
 		return false
 	}
 	s.contextIDToRootID[contextID] = rootContextID
@@ -116,7 +116,7 @@ func (s *state) createHttpContext(contextID uint32, rootContextID uint32) bool {
 
 	ctx := root.context.NewHttpContext(contextID)
 	if ctx == nil {
-		// NewHttpContext is not defined by user
+		// NewHttpContext is not defined by the user
 		return false
 	}
 	s.contextIDToRootID[contextID] = rootContextID

--- a/proxywasm/vmstate_test.go
+++ b/proxywasm/vmstate_test.go
@@ -38,34 +38,6 @@ func TestSetNewRootContext(t *testing.T) {
 	assert.Equal(t, 1, cnt)
 }
 
-func TestSetNewHttpContext(t *testing.T) {
-	currentStateMux.Lock()
-	defer currentStateMux.Unlock()
-
-	var cnt int
-	f := func(uint32, uint32) HttpContext {
-		cnt++
-		return nil
-	}
-	SetNewHttpContext(f)
-	currentState.newHttpContext(0, 0)
-	assert.Equal(t, 1, cnt)
-}
-
-func TestSetNewStreamContext(t *testing.T) {
-	currentStateMux.Lock()
-	defer currentStateMux.Unlock()
-
-	var cnt int
-	f := func(uint32, uint32) StreamContext {
-		cnt++
-		return nil
-	}
-	SetNewStreamContext(f)
-	currentState.newStreamContext(0, 0)
-	assert.Equal(t, 1, cnt)
-}
-
 func TestState_createRootContext(t *testing.T) {
 	t.Run("newRootContext exists", func(t *testing.T) {
 		type rc struct{ DefaultRootContext }
@@ -91,45 +63,71 @@ func TestState_createRootContext(t *testing.T) {
 	})
 }
 
-func TestState_createStreamContext(t *testing.T) {
-	type sc struct{ DefaultStreamContext }
+type (
+	testStateRootContext struct {
+		DefaultRootContext
+		cnt int
+	}
+	testStateStreamContext struct {
+		contextID uint32
+		DefaultStreamContext
+	}
+	testStateHttpContext struct {
+		contextID uint32
+		DefaultHttpContext
+	}
+)
 
+func (ctx *testStateRootContext) NewStreamContext(contextID uint32) StreamContext {
+	return &testStateStreamContext{contextID: contextID}
+}
+
+func (ctx *testStateRootContext) NewHttpContext(contextID uint32) HttpContext {
+	return &testStateHttpContext{contextID: contextID}
+}
+
+func TestState_createStreamContext(t *testing.T) {
 	var (
 		cid uint32 = 100
 		rid uint32 = 10
 	)
 	s := &state{
-		rootContexts:      map[uint32]*rootContextState{rid: nil},
-		streams:           map[uint32]StreamContext{},
-		newStreamContext:  func(rootContextID, contextID uint32) StreamContext { return &sc{} },
+		rootContexts: map[uint32]*rootContextState{rid: nil},
+		streams:      map[uint32]StreamContext{},
+		newRootContext: func(contextID uint32) RootContext {
+			return &testStateRootContext{}
+		},
 		contextIDToRootID: map[uint32]uint32{},
 	}
 
+	s.createRootContext(rid)
 	s.createStreamContext(cid, rid)
 	c, ok := s.streams[cid]
 	require.True(t, ok)
-	_, ok = c.(*sc)
+	ctx, ok := c.(*testStateStreamContext)
 	assert.True(t, ok)
+	assert.Equal(t, cid, ctx.contextID)
 }
 
 func TestState_createHttpContext(t *testing.T) {
-	type hc struct{ DefaultHttpContext }
-
 	var (
 		cid uint32 = 100
 		rid uint32 = 10
 	)
 	s := &state{
-		rootContexts:      map[uint32]*rootContextState{rid: nil},
-		httpStreams:       map[uint32]HttpContext{},
-		newHttpContext:    func(rootContextID, contextID uint32) HttpContext { return &hc{} },
+		rootContexts: map[uint32]*rootContextState{rid: nil},
+		httpStreams:  map[uint32]HttpContext{},
+		newRootContext: func(contextID uint32) RootContext {
+			return &testStateRootContext{}
+		},
 		contextIDToRootID: map[uint32]uint32{},
 	}
 
+	s.createRootContext(rid)
 	s.createHttpContext(cid, rid)
 	c, ok := s.httpStreams[cid]
 	require.True(t, ok)
-	_, ok = c.(*hc)
+	ctx, ok := c.(*testStateHttpContext)
 	assert.True(t, ok)
-
+	assert.Equal(t, cid, ctx.contextID)
 }

--- a/proxywasm/vmstate_test.go
+++ b/proxywasm/vmstate_test.go
@@ -64,10 +64,7 @@ func TestState_createRootContext(t *testing.T) {
 }
 
 type (
-	testStateRootContext struct {
-		DefaultRootContext
-		cnt int
-	}
+	testStateRootContext   struct{ DefaultRootContext }
 	testStateStreamContext struct {
 		contextID uint32
 		DefaultStreamContext


### PR DESCRIPTION
This is kind of an improvement from #93 in favor of https://github.com/proxy-wasm/proxy-wasm-rust-sdk/pull/34 and https://github.com/proxy-wasm/proxy-wasm-rust-sdk/pull/67

Note that this is a breaking change, though the fix is trivial.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>