### PR TITLE
Use proxy_on_memory_allocate instead of malloc.

### DIFF
--- a/proxywasm/abi_alloc.go
+++ b/proxywasm/abi_alloc.go
@@ -15,8 +15,8 @@
 package proxywasm
 
 //nolint
-//export malloc
-func malloc(size uint) *byte {
+//export proxy_on_memory_allocate
+func proxyOnMemoryAllocate(size uint) *byte {
 	buf := make([]byte, size)
 	return &buf[0]
 }


### PR DESCRIPTION
The symbol `malloc` collides with the one defined in wasi-libc, which causes the link error if we use some unhappy wasi functions

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>