### PR TITLE
Add support for foreign functions.

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -104,11 +104,19 @@ func Test_E2E(t *testing.T) {
 		staticReply: 8010,
 		admin:       28310,
 	}, accessLogger))
+
 	t.Run("dispatch_call_on_tick", testRunnerGetter(envoyPorts{
 		endpoint:    11011,
 		staticReply: 8011,
 		admin:       28311,
 	}, dispatchCallOnTick))
+
+	t.Run("foreign_call_on_tick", testRunnerGetter(envoyPorts{
+		endpoint:    11011,
+		staticReply: 8011,
+		admin:       28311,
+	}, callForeignOnTick))
+
 	t.Run("http_routing", testRunnerGetter(envoyPorts{
 		endpoint:    11012,
 		staticReply: 8012,
@@ -385,6 +393,15 @@ func accessLogger(t *testing.T, ps envoyPorts, stdErr *bytes.Buffer) {
 }
 
 func dispatchCallOnTick(t *testing.T, ps envoyPorts, stdErr *bytes.Buffer) {
+	time.Sleep(5 * time.Second)
+	out := stdErr.String()
+	fmt.Println(out)
+	for i := 1; i < 6; i++ {
+		require.Contains(t, out, fmt.Sprintf("called! %d", i))
+	}
+}
+
+func callForeignOnTick(t *testing.T, ps envoyPorts, stdErr *bytes.Buffer) {
 	time.Sleep(5 * time.Second)
 	out := stdErr.String()
 	fmt.Println(out)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -98,30 +98,26 @@ func Test_E2E(t *testing.T) {
 		staticReply: 8009,
 		admin:       28309,
 	}, configurationFromRoot))
-
 	t.Run("access_logger", testRunnerGetter(envoyPorts{
 		endpoint:    11010,
 		staticReply: 8010,
 		admin:       28310,
 	}, accessLogger))
-
 	t.Run("dispatch_call_on_tick", testRunnerGetter(envoyPorts{
 		endpoint:    11011,
 		staticReply: 8011,
 		admin:       28311,
 	}, dispatchCallOnTick))
-
-	t.Run("foreign_call_on_tick", testRunnerGetter(envoyPorts{
-		endpoint:    11011,
-		staticReply: 8011,
-		admin:       28311,
-	}, callForeignOnTick))
-
 	t.Run("http_routing", testRunnerGetter(envoyPorts{
 		endpoint:    11012,
 		staticReply: 8012,
 		admin:       28312,
 	}, httpRouting))
+	t.Run("foreign_call_on_tick", testRunnerGetter(envoyPorts{
+		endpoint:    11013,
+		staticReply: 8013,
+		admin:       28313,
+	}, callForeignOnTick))
 }
 
 type runner = func(t *testing.T, nps envoyPorts, stdErr *bytes.Buffer)
@@ -406,6 +402,6 @@ func callForeignOnTick(t *testing.T, ps envoyPorts, stdErr *bytes.Buffer) {
 	out := stdErr.String()
 	fmt.Println(out)
 	for i := 1; i < 6; i++ {
-		require.Contains(t, out, fmt.Sprintf("called! %d", i))
+		require.Contains(t, out, fmt.Sprintf("CallForeignFunction callNum: %d", i))
 	}
 }

--- a/examples/foreign_call_on_tick/README.md
+++ b/examples/foreign_call_on_tick/README.md
@@ -1,8 +1,22 @@
 ## call_foreign_function_on_tick
 
-this example periodically call foreign functions
+this example periodically call foreign functions named "compress"
 
-//TODO
 ```
-
+CallForeignFunction callNum: 1, result: 
+CallForeignFunction callNum: 1, result: 
+CallForeignFunction callNum: 2, result: 
+CallForeignFunction callNum: 2, result: 
+CallForeignFunction callNum: 3, result: 
+CallForeignFunction callNum: 3, result: 
+CallForeignFunction callNum: 4, result: 
+CallForeignFunction callNum: 4, result: 
+CallForeignFunction callNum: 5, result: 
+CallForeignFunction callNum: 5, result: 
+CallForeignFunction callNum: 6, result: 
+CallForeignFunction callNum: 6, result: 
+CallForeignFunction callNum: 7, result: 
+CallForeignFunction callNum: 7, result: 
+CallForeignFunction callNum: 8, result: 
+CallForeignFunction callNum: 8, result: 
 ```

--- a/examples/foreign_call_on_tick/README.md
+++ b/examples/foreign_call_on_tick/README.md
@@ -1,0 +1,8 @@
+## call_foreign_function_on_tick
+
+this example periodically call foreign functions
+
+//TODO
+```
+
+```

--- a/examples/foreign_call_on_tick/envoy.yaml
+++ b/examples/foreign_call_on_tick/envoy.yaml
@@ -1,0 +1,93 @@
+static_resources:
+  listeners:
+    - name: main
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 18000
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: web_service
+                http_filters:
+                  - name: envoy.filters.http.wasm
+                    typed_config:
+                      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+                      type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+                      value:
+                        config:
+                          name: "dispatch"
+                          root_id: "dispatch"
+                          vm_config:
+                            vm_id: "dispatch"
+                            runtime: "envoy.wasm.runtime.v8"
+                            code:
+                              local:
+                                filename: "./examples/foreign_call_on_tick/main.go.wasm"
+                  - name: envoy.filters.http.router
+                    typed_config: {}
+
+    - name: staticreply
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 8099
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          direct_response:
+                            status: 200
+                            body:
+                              inline_string: "example body\n"
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config: {}
+
+  clusters:
+    - name: web_service
+      connect_timeout: 0.25s
+      type: STATIC
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: mock_service
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8099
+
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/foreign_call_on_tick/main.go
+++ b/examples/foreign_call_on_tick/main.go
@@ -30,7 +30,7 @@ type rootContext struct {
 	// so that you don't need to reimplement all the methods by yourself.
 	proxywasm.DefaultRootContext
 	contextID uint32
-	callNum uint32
+	callNum   uint32
 }
 
 func newRootContext(contextID uint32) proxywasm.RootContext {

--- a/examples/foreign_call_on_tick/main.go
+++ b/examples/foreign_call_on_tick/main.go
@@ -1,0 +1,56 @@
+// Copyright 2020-2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+const tickMilliseconds uint32 = 1000
+
+func main() {
+	proxywasm.SetNewRootContext(newRootContext)
+}
+
+type rootContext struct {
+	// You'd better embed the default root context
+	// so that you don't need to reimplement all the methods by yourself.
+	proxywasm.DefaultRootContext
+	contextID uint32
+}
+
+func newRootContext(contextID uint32) proxywasm.RootContext {
+	return &rootContext{contextID: contextID}
+}
+
+// Override DefaultRootContext.
+func (ctx *rootContext) OnVMStart(vmConfigurationSize int) types.OnVMStartStatus {
+	if err := proxywasm.SetTickPeriodMilliSeconds(tickMilliseconds); err != nil {
+		proxywasm.LogCriticalf("failed to set tick period: %v", err)
+		return types.OnVMStartStatusFailed
+	}
+	proxywasm.LogInfof("set tick period milliseconds: %d", tickMilliseconds)
+	return types.OnVMStartStatusOK
+}
+
+// Override DefaultRootContext.
+func (ctx *rootContext) OnTick() {
+	ret, err := proxywasm.CallForeignFunction("hello", "hello world!")
+	if err != nil {
+		proxywasm.LogCriticalf("CallForeignFunction failed: %v", err)
+	}
+	proxywasm.LogInfof("CallForeignFunction result: %s", ret)
+}

--- a/examples/foreign_call_on_tick/main.go
+++ b/examples/foreign_call_on_tick/main.go
@@ -30,6 +30,7 @@ type rootContext struct {
 	// so that you don't need to reimplement all the methods by yourself.
 	proxywasm.DefaultRootContext
 	contextID uint32
+	callNum uint32
 }
 
 func newRootContext(contextID uint32) proxywasm.RootContext {
@@ -48,9 +49,10 @@ func (ctx *rootContext) OnVMStart(vmConfigurationSize int) types.OnVMStartStatus
 
 // Override DefaultRootContext.
 func (ctx *rootContext) OnTick() {
-	ret, err := proxywasm.CallForeignFunction("hello", "hello world!")
+	ctx.callNum++
+	ret, err := proxywasm.CallForeignFunction("compress", []byte("hello world!"))
 	if err != nil {
 		proxywasm.LogCriticalf("CallForeignFunction failed: %v", err)
 	}
-	proxywasm.LogInfof("CallForeignFunction result: %s", ret)
+	proxywasm.LogInfof("CallForeignFunction callNum: %d, result: %s", ctx.callNum, string(ret))
 }

--- a/examples/foreign_call_on_tick/main_test.go
+++ b/examples/foreign_call_on_tick/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxytest"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func TestRootContext_OnTick(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().
+		WithNewRootContext(newRootContext)
+	host := proxytest.NewHostEmulator(opt)
+
+	// Release the host emulation lock so that other test cases can insert their own host emulation.
+	defer host.Done()
+
+	// Call OnVMStart.
+	require.Equal(t, types.OnVMStartStatusOK, host.StartVM())
+	require.Equal(t, tickMilliseconds, host.GetTickPeriod())
+
+	for i := 1; i < 10; i++ {
+		host.Tick() // call OnTick
+		// Check Envoy logs.
+		logs := host.GetLogs(types.LogLevelInfo)
+		require.Contains(t, logs, fmt.Sprintf("CallForeignFunction result: %s", "hello world!"))
+	}
+
+}

--- a/examples/foreign_call_on_tick/main_test.go
+++ b/examples/foreign_call_on_tick/main_test.go
@@ -26,7 +26,7 @@ func TestRootContext_OnTick(t *testing.T) {
 		host.Tick() // call OnTick
 		// Check Envoy logs.
 		logs := host.GetLogs(types.LogLevelInfo)
-		require.Contains(t, logs, fmt.Sprintf("CallForeignFunction result: %s", "hello world!"))
+		require.Contains(t, logs, fmt.Sprintf("CallForeignFunction callNum: %d, result: %s", i, "hello world!"))
 	}
 
 }

--- a/proxytest/root.go
+++ b/proxytest/root.go
@@ -263,6 +263,27 @@ func (r *rootHostEmulator) ProxyHttpCall(upstreamData *byte, upstreamSize int, h
 	return types.StatusOK
 }
 
+var funcMap = map[string]func(string)string {
+	"hello":func (param string) string {
+				return param
+			},
+}
+
+// impl rawhostcall.ProxyWASMHost
+func (r *rootHostEmulator) ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) types.Status {
+	funcName := proxywasm.RawBytePtrToString(funcNamePtr, funcNameSize)
+	param := proxywasm.RawBytePtrToString(paramPtr, paramSize)
+
+	log.Printf("[foreign call] funcname: %s", funcName)
+	log.Printf("[foreign call] param: %s", param)
+
+	ret := funcMap[funcName](param)
+	*returnData = &[]byte(ret)[0]
+	*returnSize = len(ret)
+
+	return types.StatusOK
+}
+
 // // impl rawhostcall.ProxyWASMHost: delegated from hostEmulator
 func (r *rootHostEmulator) rootHostEmulatorProxyGetHeaderMapPairs(mapType types.MapType, returnValueData **byte, returnValueSize *int) types.Status {
 	res, ok := r.httpCalloutResponse[r.activeCalloutID]

--- a/proxytest/root.go
+++ b/proxytest/root.go
@@ -263,10 +263,10 @@ func (r *rootHostEmulator) ProxyHttpCall(upstreamData *byte, upstreamSize int, h
 	return types.StatusOK
 }
 
-var foreignFunctions = map[string]func([]byte)[]byte {
-	"compress":func (param []byte) []byte {
-				return param
-			},
+var foreignFunctions = map[string]func([]byte) []byte{
+	"compress": func(param []byte) []byte {
+		return param
+	},
 }
 
 // impl rawhostcall.ProxyWASMHost

--- a/proxytest/root.go
+++ b/proxytest/root.go
@@ -263,8 +263,8 @@ func (r *rootHostEmulator) ProxyHttpCall(upstreamData *byte, upstreamSize int, h
 	return types.StatusOK
 }
 
-var funcMap = map[string]func(string)string {
-	"hello":func (param string) string {
+var foreignFunctions = map[string]func([]byte)[]byte {
+	"compress":func (param []byte) []byte {
 				return param
 			},
 }
@@ -272,13 +272,13 @@ var funcMap = map[string]func(string)string {
 // impl rawhostcall.ProxyWASMHost
 func (r *rootHostEmulator) ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) types.Status {
 	funcName := proxywasm.RawBytePtrToString(funcNamePtr, funcNameSize)
-	param := proxywasm.RawBytePtrToString(paramPtr, paramSize)
+	param := proxywasm.RawBytePtrToByteSlice(paramPtr, paramSize)
 
 	log.Printf("[foreign call] funcname: %s", funcName)
 	log.Printf("[foreign call] param: %s", param)
 
-	ret := funcMap[funcName](param)
-	*returnData = &[]byte(ret)[0]
+	ret := foreignFunctions[funcName](param)
+	*returnData = &ret[0]
 	*returnSize = len(ret)
 
 	return types.StatusOK

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -82,6 +82,22 @@ func GetHttpCallResponseTrailers() (types.Trailers, error) {
 	return ret, types.StatusToError(st)
 }
 
+func DispatchForeignFuncCall(funcName string, param string) (ret string, err error) {
+	f := stringBytePtr(funcName)
+	p := stringBytePtr(param)
+
+	var returnData *byte
+	var returnSize int
+
+	switch st := rawhostcall.ProxyCallForeignFunction(f, len(funcName), p, len(param), &returnData, &returnSize); st {
+	case types.StatusOK:
+		return RawBytePtrToString(returnData, returnSize), nil
+	default:
+		return "", types.StatusToError(st)
+	}
+}
+
+
 func GetDownStreamData(start, maxSize int) ([]byte, error) {
 	ret, st := getBuffer(types.BufferTypeDownstreamData, start, maxSize)
 	return ret, types.StatusToError(st)

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -96,7 +96,6 @@ func CallForeignFunction(funcName string, param []byte) (ret []byte, err error) 
 	}
 }
 
-
 func GetDownStreamData(start, maxSize int) ([]byte, error) {
 	ret, st := getBuffer(types.BufferTypeDownstreamData, start, maxSize)
 	return ret, types.StatusToError(st)

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -82,7 +82,7 @@ func GetHttpCallResponseTrailers() (types.Trailers, error) {
 	return ret, types.StatusToError(st)
 }
 
-func DispatchForeignFuncCall(funcName string, param string) (ret string, err error) {
+func CallForeignFunction(funcName string, param string) (ret string, err error) {
 	f := stringBytePtr(funcName)
 	p := stringBytePtr(param)
 

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -82,18 +82,17 @@ func GetHttpCallResponseTrailers() (types.Trailers, error) {
 	return ret, types.StatusToError(st)
 }
 
-func CallForeignFunction(funcName string, param string) (ret string, err error) {
+func CallForeignFunction(funcName string, param []byte) (ret []byte, err error) {
 	f := stringBytePtr(funcName)
-	p := stringBytePtr(param)
 
 	var returnData *byte
 	var returnSize int
 
-	switch st := rawhostcall.ProxyCallForeignFunction(f, len(funcName), p, len(param), &returnData, &returnSize); st {
+	switch st := rawhostcall.ProxyCallForeignFunction(f, len(funcName), &param[0], len(param), &returnData, &returnSize); st {
 	case types.StatusOK:
-		return RawBytePtrToString(returnData, returnSize), nil
+		return RawBytePtrToByteSlice(returnData, returnSize), nil
 	default:
-		return "", types.StatusToError(st)
+		return nil, types.StatusToError(st)
 	}
 }
 

--- a/proxywasm/rawhostcall/rawhostcall.go
+++ b/proxywasm/rawhostcall/rawhostcall.go
@@ -80,6 +80,9 @@ func ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, heade
 	bodyData *byte, bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32,
 ) types.Status
 
+//export proxy_call_foreign_function
+func ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) types.Status
+
 //export proxy_set_tick_period_milliseconds
 func ProxySetTickPeriodMilliseconds(period uint32) types.Status
 

--- a/proxywasm/rawhostcall/rawhostcall_mock.go
+++ b/proxywasm/rawhostcall/rawhostcall_mock.go
@@ -46,6 +46,7 @@ type ProxyWASMHost interface {
 	ProxyGetBufferBytes(bt types.BufferType, start int, maxSize int, returnBufferData **byte, returnBufferSize *int) types.Status
 	ProxySetBufferBytes(bt types.BufferType, start int, maxSize int, bufferData *byte, bufferSize int) types.Status
 	ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, headerSize int, bodyData *byte, bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) types.Status
+	ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) types.Status
 	ProxySetTickPeriodMilliseconds(period uint32) types.Status
 	ProxySetEffectiveContext(contextID uint32) types.Status
 	ProxyDone() types.Status
@@ -116,6 +117,9 @@ func (d DefaultProxyWAMSHost) ProxySetBufferBytes(bt types.BufferType, start int
 	return 0
 }
 func (d DefaultProxyWAMSHost) ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, headerSize int, bodyData *byte, bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) types.Status {
+	return 0
+}
+func (d DefaultProxyWAMSHost) ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) types.Status {
 	return 0
 }
 func (d DefaultProxyWAMSHost) ProxySetTickPeriodMilliseconds(period uint32) types.Status { return 0 }
@@ -217,6 +221,10 @@ func ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, heade
 	bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) types.Status {
 	return currentHost.ProxyHttpCall(upstreamData, upstreamSize,
 		headerData, headerSize, bodyData, bodySize, trailersData, trailersSize, timeout, calloutIDPtr)
+}
+
+func ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) types.Status {
+	return currentHost.ProxyCallForeignFunction(funcNamePtr, funcNameSize, paramPtr, paramSize, returnData, returnSize)
 }
 
 func ProxySetTickPeriodMilliseconds(period uint32) types.Status {


### PR DESCRIPTION
recently,  i want to call the host function in my wasm,  i found there is a spec define this interface `proxy_call_foreign_function `

more info: https://github.com/proxy-wasm/spec/tree/master/abi-versions/vNEXT#foreign-function-interface-ffi

my wasm is written by golang, so i use this repo in my project, but it doesn't implement `proxy_call_foreign_function `, so i do this.
