### PR TITLE
Rename OnVMDone to OnPluginDone

### DIFF
--- a/proxywasm/abi_lifecycle.go
+++ b/proxywasm/abi_lifecycle.go
@@ -53,7 +53,7 @@ func proxyOnDone(contextID uint32) bool {
 		return true
 	} else if ctx, ok := currentState.rootContexts[contextID]; ok {
 		currentState.setActiveContextID(contextID)
-		response := ctx.context.OnVMDone()
+		response := ctx.context.OnPluginDone()
 		return response
 	} else {
 		panic("invalid context on proxy_on_done")

--- a/proxywasm/abi_lifecycle_test.go
+++ b/proxywasm/abi_lifecycle_test.go
@@ -78,7 +78,7 @@ type lifecycleContext struct {
 	onDoneCalled, onLogCalled bool
 }
 
-func (ctx *lifecycleContext) OnVMDone() bool {
+func (ctx *lifecycleContext) OnPluginDone() bool {
 	ctx.onDoneCalled = true
 	return true
 }

--- a/proxywasm/context.go
+++ b/proxywasm/context.go
@@ -23,7 +23,7 @@ type RootContext interface {
 	OnTick()
 	OnVMStart(vmConfigurationSize int) types.OnVMStartStatus
 	OnPluginStart(pluginConfigurationSize int) types.OnPluginStartStatus
-	OnVMDone() bool
+	OnPluginDone() bool
 	OnLog()
 
 	// Child context factories
@@ -71,7 +71,7 @@ func (*DefaultRootContext) OnVMStart(int) types.OnVMStartStatus { return types.O
 func (*DefaultRootContext) OnPluginStart(int) types.OnPluginStartStatus {
 	return types.OnPluginStartStatusOK
 }
-func (*DefaultRootContext) OnVMDone() bool                        { return true }
+func (*DefaultRootContext) OnPluginDone() bool                    { return true }
 func (*DefaultRootContext) OnLog()                                {}
 func (*DefaultRootContext) NewStreamContext(uint32) StreamContext { return nil }
 func (*DefaultRootContext) NewHttpContext(uint32) HttpContext     { return nil }


### PR DESCRIPTION
OnDone is called for each root context so VMDone is not accurate.
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>