### PR TITLE
Add Append/Prepend/Replace buffers, and remove SetBuffer to disambiguate.

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -17,7 +17,7 @@ package e2e
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -132,7 +132,7 @@ func Test_http_body(t *testing.T) {
 			return false
 		}
 		defer res.Body.Close()
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		return checkMessage(stdErr.String(), []string{
 			"body size: 21",
@@ -172,7 +172,7 @@ func Test_http_routing(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		raw, err := ioutil.ReadAll(res.Body)
+		raw, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		defer res.Body.Close()
 		body := string(raw)
@@ -207,7 +207,7 @@ func Test_metrics(t *testing.T) {
 			return false
 		}
 		defer res.Body.Close()
-		raw, err := ioutil.ReadAll(res.Body)
+		raw, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		return checkMessage(string(raw), []string{fmt.Sprintf("proxy_wasm_go.request_counter: %d", count)}, nil)
 	}, 5*time.Second, time.Millisecond, "Expected stats not found")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -123,23 +123,37 @@ func Test_http_auth_random(t *testing.T) {
 func Test_http_body(t *testing.T) {
 	stdErr, kill := startEnvoy(t, 8001)
 	defer kill()
-	req, err := http.NewRequest("PUT", "http://localhost:18000/anything",
-		bytes.NewBuffer([]byte(`{ "initial": "body" }`)))
-	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		res, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return false
-		}
-		defer res.Body.Close()
-		body, err := io.ReadAll(res.Body)
-		require.NoError(t, err)
-		return checkMessage(stdErr.String(), []string{
-			`initial request body: { "initial": "body" }`,
-			"on http request body finished"},
-			[]string{"failed to set request body", "failed to get request body"},
-		) && checkMessage(string(body), []string{`"another": "body"`}, nil)
-	}, 5*time.Second, 500*time.Millisecond, stdErr.String())
+
+	for _, tc := range []struct {
+		op, expBody string
+	}{
+		{op: "append", expBody: `[original body][this is appended body]`},
+		{op: "prepend", expBody: `[this is prepended body][original body]`},
+		{op: "replace", expBody: `[this is replaced body]`},
+		// Shoud fall back to to the replace.
+		{op: "invalid", expBody: `[this is replaced body]`},
+	} {
+		t.Run(tc.op, func(t *testing.T) {
+			require.Eventually(t, func() bool {
+				req, err := http.NewRequest("PUT", "http://localhost:18000/anything",
+					bytes.NewBuffer([]byte(`[original body]`)))
+				require.NoError(t, err)
+				req.Header.Add("buffer-operation", tc.op)
+				res, err := http.DefaultClient.Do(req)
+				if err != nil {
+					return false
+				}
+				defer res.Body.Close()
+				body, err := io.ReadAll(res.Body)
+				require.NoError(t, err)
+				return string(body) == tc.expBody &&
+					checkMessage(stdErr.String(), []string{
+						`original request body: [original body]`},
+						[]string{"failed to"},
+					) && checkMessage(string(body), []string{tc.expBody}, nil)
+			}, 5*time.Second, 500*time.Millisecond, stdErr.String())
+		})
+	}
 }
 
 func Test_http_headers(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -123,7 +123,7 @@ func Test_http_auth_random(t *testing.T) {
 func Test_http_body(t *testing.T) {
 	stdErr, kill := startEnvoy(t, 8001)
 	defer kill()
-	req, err := http.NewRequest("GET", "http://localhost:18000/anything",
+	req, err := http.NewRequest("PUT", "http://localhost:18000/anything",
 		bytes.NewBuffer([]byte(`{ "initial": "body" }`)))
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
@@ -135,7 +135,6 @@ func Test_http_body(t *testing.T) {
 		body, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		return checkMessage(stdErr.String(), []string{
-			"body size: 21",
 			`initial request body: { "initial": "body" }`,
 			"on http request body finished"},
 			[]string{"failed to set request body", "failed to get request body"},

--- a/examples/http_body/README.md
+++ b/examples/http_body/README.md
@@ -1,9 +1,15 @@
 ## http_body
 
-this example replaces the request body
+this example demnstrates how to perform operation on a request body like append/prepend/replace.
+
 
 ```
-2020/10/12 13:41:31 proxy_info_log: body size: 29
-2020/10/12 13:41:31 proxy_info_log: initial request body: { "initial": "request body" }
-2020/10/12 13:41:31 proxy_info_log: on http request body finished
+$ curl -XPUT localhost:18000 --data '[initial body]' -H "buffer-operation: prepend"
+[this is prepended body][initial body]
+
+$ curl -XPUT localhost:18000 --data '[initial body]' -H "buffer-operation: append"
+[initial body][this is appended body]
+
+$ curl -XPUT localhost:18000 --data '[initial body]' -H "buffer-operation: replace"
+[this is replaced body]
 ```

--- a/examples/http_body/envoy.yaml
+++ b/examples/http_body/envoy.yaml
@@ -66,7 +66,7 @@ static_resources:
                         - match:
                             prefix: "/"
                           route:
-                            cluster: echo
+                            cluster: admin
                 http_filters:
                   - name: envoy.filters.http.wasm
                     typed_config:
@@ -102,6 +102,20 @@ static_resources:
                     socket_address:
                       address: 0.0.0.0
                       port_value: 38140
+    - name: admin
+      connect_timeout: 5000s
+      type: strict_dns
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: admin
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 0.0.0.0
+                      port_value: 8001
+
 
 admin:
   access_log_path: "/dev/null"

--- a/examples/http_body/main.go
+++ b/examples/http_body/main.go
@@ -58,12 +58,16 @@ type setBodyContext struct {
 
 // Override DefaultHttpContext.
 func (ctx *setBodyContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
-	// Remove Content-Length in order to prevent severs from crashing if we set different body from downstream.
-	if err := proxywasm.RemoveHttpRequestHeader("content-length"); err != nil {
+	if _, err := proxywasm.GetHttpRequestHeader("content-length"); err != nil {
 		if err := proxywasm.SendHttpResponse(400, nil, []byte("content must be provided")); err != nil {
 			panic(err)
 		}
 		return types.ActionPause
+	}
+
+	// Remove Content-Length in order to prevent severs from crashing if we set different body from downstream.
+	if err := proxywasm.RemoveHttpRequestHeader("content-length"); err != nil {
+		panic(err)
 	}
 	return types.ActionContinue
 }

--- a/examples/http_body/main.go
+++ b/examples/http_body/main.go
@@ -70,7 +70,7 @@ func (ctx *setBodyContext) OnHttpRequestBody(bodySize int, endOfStream bool) typ
 
 		b := []byte(`{ "another": "body" }`)
 
-		err = proxywasm.SetHttpRequestBody(b)
+		err = proxywasm.ReplaceHttpRequestBody(b)
 		if err != nil {
 			proxywasm.LogErrorf("failed to set request body: %v", err)
 			return types.ActionContinue

--- a/examples/http_body/main.go
+++ b/examples/http_body/main.go
@@ -57,7 +57,7 @@ type setBodyContext struct {
 }
 
 // Override DefaultHttpContext.
-func (ctx *setBodyContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) types.Action {
+func (ctx *setBodyContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
 	// Remove Content-Length in order to prevent severs from crashing if we set different body from downstream.
 	if err := proxywasm.RemoveHttpRequestHeader("content-length"); err != nil {
 		if err := proxywasm.SendHttpResponse(400, nil, []byte("content must be provided")); err != nil {

--- a/examples/http_body/main_test.go
+++ b/examples/http_body/main_test.go
@@ -20,7 +20,7 @@ func TestHttpBody_OnHttpRequestBody(t *testing.T) {
 	id := host.InitializeHttpContext()
 
 	// Call OnRequestBody.
-	action := host.CallOnRequestBody(id, []byte(`{ "initial": "request body" }`), false)
+	action := host.CallOnRequestBody(id, []byte(`{ "initial": "request body" }`), true)
 	require.Equal(t, types.ActionContinue, action)
 
 	logs := host.GetLogs(types.LogLevelInfo)
@@ -28,5 +28,4 @@ func TestHttpBody_OnHttpRequestBody(t *testing.T) {
 	// Check Envoy logs.
 	require.Contains(t, logs, "on http request body finished")
 	require.Contains(t, logs, `initial request body: { "initial": "request body" }`)
-	require.Contains(t, logs, "body size: 29")
 }

--- a/examples/http_body/main_test.go
+++ b/examples/http_body/main_test.go
@@ -9,23 +9,124 @@ import (
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
 )
 
-func TestHttpBody_OnHttpRequestBody(t *testing.T) {
+func TestSetBodyContext_OnHttpRequestHeaders(t *testing.T) {
 	opt := proxytest.NewEmulatorOption().
 		WithNewRootContext(newContext)
 	host := proxytest.NewHostEmulator(opt)
 	// Release the host emulation lock so that other test cases can insert their own host emulation.
 	defer host.Done()
 
-	// Create http context.
-	id := host.InitializeHttpContext()
+	t.Run("remove content length", func(t *testing.T) {
+		// Create http context.
+		id := host.InitializeHttpContext()
 
-	// Call OnRequestBody.
-	action := host.CallOnRequestBody(id, []byte(`{ "initial": "request body" }`), true)
-	require.Equal(t, types.ActionContinue, action)
+		// Call OnRequestHeaders.
+		action := host.CallOnRequestHeaders(id, types.Headers{
+			{"content-length", "10"},
+		}, false)
 
-	logs := host.GetLogs(types.LogLevelInfo)
+		// Must be continued.
+		require.Equal(t, types.ActionContinue, action)
 
-	// Check Envoy logs.
-	require.Contains(t, logs, "on http request body finished")
-	require.Contains(t, logs, `initial request body: { "initial": "request body" }`)
+		// Check the final request headers
+		headers := host.GetCurrentRequestHeaders(id)
+		require.Len(t, headers, 0, "content-length header must be removed.")
+	})
+
+	t.Run("400 response", func(t *testing.T) {
+		// Create http context.
+		id := host.InitializeHttpContext()
+
+		// Call OnRequestHeaders without "content-length"
+		action := host.CallOnRequestHeaders(id, nil, false)
+
+		// Must be paused.
+		require.Equal(t, types.ActionPause, action)
+
+		// Check the local response.
+		localResponse := host.GetSentLocalResponse(id)
+		require.NotNil(t, localResponse)
+		require.Equal(t, uint32(400), localResponse.StatusCode)
+		require.Equal(t, "content must be provided", string(localResponse.Data))
+	})
+}
+
+func TestSetBodyContext_OnHttpRequestBody(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().
+		WithNewRootContext(newContext)
+	host := proxytest.NewHostEmulator(opt)
+	// Release the host emulation lock so that other test cases can insert their own host emulation.
+	defer host.Done()
+
+	t.Run("pause until EOS", func(t *testing.T) {
+		// Create http context.
+		id := host.InitializeHttpContext()
+
+		// Call OnRequestBody.
+		action := host.CallOnRequestBody(id, []byte("aaaa"), false /* end of stream */)
+
+		// Must be paused
+		require.Equal(t, types.ActionPause, action)
+	})
+
+	t.Run("body replacement", func(t *testing.T) {
+		// Create http context.
+		id := host.InitializeHttpContext()
+
+		// Call OnRequestBody.
+		action := host.CallOnRequestBody(id, []byte(`{ "initial": "request body" }`), true)
+		require.Equal(t, types.ActionContinue, action)
+
+		// Check Envoy logs.
+		logs := host.GetLogs(types.LogLevelInfo)
+		require.Contains(t, logs, "on http request body finished")
+		require.Contains(t, logs, `initial request body: { "initial": "request body" }`)
+	})
+}
+
+func TestEchoBodyContext_OnHttpRequestBody(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().
+		WithNewRootContext(newContext).
+		WithPluginConfiguration([]byte("echo"))
+	host := proxytest.NewHostEmulator(opt)
+	// Release the host emulation lock so that other test cases can insert their own host emulation.
+	defer host.Done()
+
+	require.Equal(t, types.OnPluginStartStatusOK, host.StartPlugin())
+
+	t.Run("pause until EOS", func(t *testing.T) {
+		// Create http context.
+		id := host.InitializeHttpContext()
+
+		// Call OnRequestBody.
+		action := host.CallOnRequestBody(id, []byte("aaaa"), false /* end of stream */)
+
+		// Must be paused
+		require.Equal(t, types.ActionPause, action)
+	})
+
+	t.Run("echo request", func(t *testing.T) {
+		// Create http context.
+		id := host.InitializeHttpContext()
+
+		for _, frame := range []string{"frame1...", "frame2..."} {
+			// Call OnRequestHeaders without "content-length"
+			action := host.CallOnRequestBody(id, []byte(frame), false /* end of stream */)
+
+			// Must be paused.
+			require.Equal(t, types.ActionPause, action)
+		}
+
+		// End stream.
+		action := host.CallOnRequestBody(id, nil, true /* end of stream */)
+
+		// Must be paused.
+		require.Equal(t, types.ActionPause, action)
+
+		// Check the local response.
+		localResponse := host.GetSentLocalResponse(id)
+		require.NotNil(t, localResponse)
+		require.Equal(t, uint32(200), localResponse.StatusCode)
+		require.Equal(t, "frame1...frame2...", string(localResponse.Data))
+	})
 }

--- a/proxytest/http.go
+++ b/proxytest/http.go
@@ -435,6 +435,15 @@ func (h *httpHostEmulator) GetCurrentRequestHeaders(contextID uint32) types.Head
 }
 
 // impl HostEmulator
+func (h *httpHostEmulator) GetCurrentRequestBody(contextID uint32) []byte {
+	stream, ok := h.httpStreams[contextID]
+	if !ok {
+		log.Fatalf("invalid context id: %d", contextID)
+	}
+	return stream.requestBody
+}
+
+// impl HostEmulator
 func (h *httpHostEmulator) GetSentLocalResponse(contextID uint32) *LocalHttpResponse {
 	return h.httpStreams[contextID].sentLocalResponse
 }

--- a/proxytest/proxytest.go
+++ b/proxytest/proxytest.go
@@ -15,6 +15,7 @@
 package proxytest
 
 import (
+	"fmt"
 	"log"
 	"sync"
 
@@ -136,7 +137,7 @@ func (h *hostEmulator) ProxySetBufferBytes(bt types.BufferType, start int, maxSi
 	case types.BufferTypeHttpRequestBody, types.BufferTypeHttpResponseBody:
 		return h.httpHostEmulatorProxySetBufferBytes(bt, start, maxSize, bufferData, bufferSize)
 	default:
-		panic("unreachable: maybe a bug in this host emulation or SDK")
+		panic(fmt.Sprintf("buffer type %d is not supported by proxytest frame work yet", bt))
 	}
 }
 

--- a/proxytest/proxytest.go
+++ b/proxytest/proxytest.go
@@ -61,6 +61,7 @@ type HostEmulator interface {
 	CompleteHttpContext(contextID uint32)
 	GetCurrentHttpStreamAction(contextID uint32) types.Action
 	GetCurrentRequestHeaders(contextID uint32) types.Headers
+	GetCurrentRequestBody(contextID uint32) []byte
 	GetSentLocalResponse(contextID uint32) *LocalHttpResponse
 	CallOnLogForAccessLogger(requestHeaders, responseHeaders types.Headers)
 }

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -107,12 +107,12 @@ func GetDownStreamData(start, maxSize int) ([]byte, error) {
 	return ret, types.StatusToError(st)
 }
 
-func PrependDownStreamData(data []byte) error {
-	return prependToBuffer(types.BufferTypeDownstreamData, data)
-}
-
 func AppendDownStreamData(data []byte) error {
 	return appendToBuffer(types.BufferTypeDownstreamData, data)
+}
+
+func PrependDownStreamData(data []byte) error {
+	return prependToBuffer(types.BufferTypeDownstreamData, data)
 }
 
 func ReplaceDownStreamData(data []byte) error {
@@ -124,12 +124,12 @@ func GetUpstreamData(start, maxSize int) ([]byte, error) {
 	return ret, types.StatusToError(st)
 }
 
-func PrependUpstreamData(data []byte) error {
-	return prependToBuffer(types.BufferTypeUpstreamData, data)
-}
-
 func AppendUpstreammData(data []byte) error {
 	return appendToBuffer(types.BufferTypeUpstreamData, data)
+}
+
+func PrependUpstreamData(data []byte) error {
+	return prependToBuffer(types.BufferTypeUpstreamData, data)
 }
 
 func ReplaceUpstreamData(data []byte) error {
@@ -183,12 +183,12 @@ func GetHttpRequestBody(start, maxSize int) ([]byte, error) {
 	return ret, types.StatusToError(st)
 }
 
-func PrependHttpRequestBody(data []byte) error {
-	return prependToBuffer(types.BufferTypeHttpRequestBody, data)
-}
-
 func AppendHttpRequestBody(data []byte) error {
 	return appendToBuffer(types.BufferTypeHttpRequestBody, data)
+}
+
+func PrependHttpRequestBody(data []byte) error {
+	return prependToBuffer(types.BufferTypeHttpRequestBody, data)
 }
 
 func ReplaceHttpRequestBody(data []byte) error {
@@ -256,12 +256,12 @@ func GetHttpResponseBody(start, maxSize int) ([]byte, error) {
 	return ret, types.StatusToError(st)
 }
 
-func PrependHttpResponseBody(data []byte) error {
-	return prependToBuffer(types.BufferTypeHttpResponseBody, data)
-}
-
 func AppendHttpResponseBody(data []byte) error {
 	return appendToBuffer(types.BufferTypeHttpResponseBody, data)
+}
+
+func PrependHttpResponseBody(data []byte) error {
+	return prependToBuffer(types.BufferTypeHttpResponseBody, data)
 }
 
 func ReplaceHttpResponseBody(data []byte) error {
@@ -422,20 +422,20 @@ func getBuffer(bufType types.BufferType, start, maxSize int) ([]byte, types.Stat
 	}
 }
 
-func prependToBuffer(bufType types.BufferType, buffer []byte) error {
-	var bufferData *byte
-	if len(buffer) != 0 {
-		bufferData = &buffer[0]
-	}
-	return types.StatusToError(rawhostcall.ProxySetBufferBytes(bufType, 0, 0, bufferData, len(buffer)))
-}
-
 func appendToBuffer(bufType types.BufferType, buffer []byte) error {
 	var bufferData *byte
 	if len(buffer) != 0 {
 		bufferData = &buffer[0]
 	}
 	return types.StatusToError(rawhostcall.ProxySetBufferBytes(bufType, math.MaxInt32, 0, bufferData, len(buffer)))
+}
+
+func prependToBuffer(bufType types.BufferType, buffer []byte) error {
+	var bufferData *byte
+	if len(buffer) != 0 {
+		bufferData = &buffer[0]
+	}
+	return types.StatusToError(rawhostcall.ProxySetBufferBytes(bufType, 0, 0, bufferData, len(buffer)))
 }
 
 func replaceBuffer(bufType types.BufferType, buffer []byte) error {

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -15,6 +15,8 @@
 package proxywasm
 
 import (
+	"math"
+
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/rawhostcall"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
 )
@@ -101,13 +103,16 @@ func GetDownStreamData(start, maxSize int) ([]byte, error) {
 	return ret, types.StatusToError(st)
 }
 
-func SetDownStreamData(body []byte) error {
-	var bufferData *byte
-	if len(body) != 0 {
-		bufferData = &body[0]
-	}
-	st := rawhostcall.ProxySetBufferBytes(types.BufferTypeDownstreamData, 0, len(body), bufferData, len(body))
-	return types.StatusToError(st)
+func PrependDownStreamData(data []byte) error {
+	return prependToBuffer(types.BufferTypeDownstreamData, data)
+}
+
+func AppendDownStreamData(data []byte) error {
+	return appendToBuffer(types.BufferTypeDownstreamData, data)
+}
+
+func ReplaceDownStreamData(data []byte) error {
+	return replaceBuffer(types.BufferTypeDownstreamData, data)
 }
 
 func GetUpstreamData(start, maxSize int) ([]byte, error) {
@@ -115,13 +120,16 @@ func GetUpstreamData(start, maxSize int) ([]byte, error) {
 	return ret, types.StatusToError(st)
 }
 
-func SetUpstreamData(body []byte) error {
-	var bufferData *byte
-	if len(body) != 0 {
-		bufferData = &body[0]
-	}
-	st := rawhostcall.ProxySetBufferBytes(types.BufferTypeUpstreamData, 0, len(body), bufferData, len(body))
-	return types.StatusToError(st)
+func PrependUpstreamData(data []byte) error {
+	return prependToBuffer(types.BufferTypeUpstreamData, data)
+}
+
+func AppendUpstreammData(data []byte) error {
+	return appendToBuffer(types.BufferTypeUpstreamData, data)
+}
+
+func ReplaceUpstreamData(data []byte) error {
+	return replaceBuffer(types.BufferTypeUpstreamData, data)
 }
 
 func ContinueDownStream() error {
@@ -171,13 +179,16 @@ func GetHttpRequestBody(start, maxSize int) ([]byte, error) {
 	return ret, types.StatusToError(st)
 }
 
-func SetHttpRequestBody(body []byte) error {
-	var bufferData *byte
-	if len(body) != 0 {
-		bufferData = &body[0]
-	}
-	st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpRequestBody, 0, len(body), bufferData, len(body))
-	return types.StatusToError(st)
+func PrependHttpRequestBody(data []byte) error {
+	return prependToBuffer(types.BufferTypeHttpRequestBody, data)
+}
+
+func AppendHttpRequestBody(data []byte) error {
+	return appendToBuffer(types.BufferTypeHttpRequestBody, data)
+}
+
+func ReplaceHttpRequestBody(data []byte) error {
+	return replaceBuffer(types.BufferTypeHttpRequestBody, data)
 }
 
 func GetHttpRequestTrailers() (types.Trailers, error) {
@@ -241,13 +252,16 @@ func GetHttpResponseBody(start, maxSize int) ([]byte, error) {
 	return ret, types.StatusToError(st)
 }
 
-func SetHttpResponseBody(body []byte) error {
-	var bufferData *byte
-	if len(body) != 0 {
-		bufferData = &body[0]
-	}
-	st := rawhostcall.ProxySetBufferBytes(types.BufferTypeHttpResponseBody, 0, len(body), bufferData, len(body))
-	return types.StatusToError(st)
+func PrependHttpResponseBody(data []byte) error {
+	return prependToBuffer(types.BufferTypeHttpResponseBody, data)
+}
+
+func AppendHttpResponseBody(data []byte) error {
+	return appendToBuffer(types.BufferTypeHttpResponseBody, data)
+}
+
+func ReplaceHttpResponseBody(data []byte) error {
+	return replaceBuffer(types.BufferTypeHttpResponseBody, data)
 }
 
 func GetHttpResponseTrailers() (types.Trailers, error) {
@@ -402,4 +416,28 @@ func getBuffer(bufType types.BufferType, start, maxSize int) ([]byte, types.Stat
 	default:
 		return nil, st
 	}
+}
+
+func prependToBuffer(bufType types.BufferType, buffer []byte) error {
+	var bufferData *byte
+	if len(buffer) != 0 {
+		bufferData = &buffer[0]
+	}
+	return types.StatusToError(rawhostcall.ProxySetBufferBytes(bufType, 0, 0, bufferData, len(buffer)))
+}
+
+func appendToBuffer(bufType types.BufferType, buffer []byte) error {
+	var bufferData *byte
+	if len(buffer) != 0 {
+		bufferData = &buffer[0]
+	}
+	return types.StatusToError(rawhostcall.ProxySetBufferBytes(bufType, math.MaxInt32, 0, bufferData, len(buffer)))
+}
+
+func replaceBuffer(bufType types.BufferType, buffer []byte) error {
+	var bufferData *byte
+	if len(buffer) != 0 {
+		bufferData = &buffer[0]
+	}
+	return types.StatusToError(rawhostcall.ProxySetBufferBytes(bufType, 0, math.MaxInt32, bufferData, len(buffer)))
 }

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -33,12 +33,16 @@ func GetVMConfiguration(size int) ([]byte, error) {
 
 func SendHttpResponse(statusCode uint32, headers types.Headers, body []byte) error {
 	shs := SerializeMap(headers)
+	var bp *byte
+	if len(body) > 0 {
+		bp = &body[0]
+	}
 	hp := &shs[0]
 	hl := len(shs)
 	return types.StatusToError(
 		rawhostcall.ProxySendLocalResponse(
 			statusCode, nil, 0,
-			&body[0], len(body), hp, hl, -1,
+			bp, len(body), hp, hl, -1,
 		),
 	)
 }


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

resolves #117 

Implemented the API by @pwoelfle https://github.com/tetratelabs/proxy-wasm-go-sdk/issues/117#issuecomment-789530828. 
