### PR TITLE
Use Go 1.16.5 on CI

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.5'
 
       - name: checkout
         uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.5'
 
       - name: checkout
         uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.5'
 
       # TinyGo's release container does not have Make command.
       - name: install Make
@@ -85,7 +85,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.5'
 
       - name: install Make
         run: apt update && apt install make


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>