### PR TITLE
doc: cleanup README, fix typo of WASM to Wasm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ make test.e2e.single name=helloworld
      for saving the plugin's [state](https://github.com/tetratelabs/proxy-wasm-go-sdk/blob/cf6ad74ed58b284d3d8ceeb8c5dba2280d5b1007/proxywasm/vmstate.go#L41-L46).
     - Theoretically, we can implement our own GC algorithms tailored for proxy-wasm through `alloc(uintptr)` [interface](https://github.com/tinygo-org/tinygo/blob/v0.14.1/src/runtime/gc_none.go#L13) 
     with `-gc=none` option. This is the future TODO.
-- `recover` is [not implemented](https://github.com/tinygo-org/tinygo/issues/891) in TinyGo, and there's no way to prevent the WASM virtual machine from aborting.
+- `recover` is [not implemented](https://github.com/tinygo-org/tinygo/issues/891) in TinyGo, and there's no way to prevent the Wasm virtual machine from aborting.
 - Goroutine support
     - In TinyGo, Goroutine is implmeneted through LLVM's coroutine (see [this blog post](https://aykevl.nl/2019/02/tinygo-goroutines)).
-    - In Envoy, WASM modules are run in the event driven manner, and therefore the "scheduler" is not executed once the main function exits. 
+    - In Envoy, Wasm modules are run in the event driven manner, and therefore the "scheduler" is not executed once the main function exits.
         That means you cannot have the expected behavior of Goroutine as in ordinary host environments.
-        - The question "How to deal with Goroutine in a thread local WASM VM executed in the event drive manner" has yet to be answered.
+        - The question "How to deal with Goroutine in a thread local Wasm VM executed in the event drive manner" has yet to be answered.
     - We strongly recommend that you implement the `OnTick` function for any asynchronous task instead of using Goroutine.
     - The scheduler can be disabled with `-scheduler=none` option of TinyGo.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
-# WebAssembly for Proxies (Go SDK)
-
-[![Build](https://github.com/tetratelabs/proxy-wasm-go-sdk/workflows/test/badge.svg)](https://github.com/tetratelabs/proxy-wasm-go-sdk/actions)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-
 __This project is in its early stage, and the API is likely to change and not stable.__
+
+# WebAssembly for Proxies (Go SDK) [![Build](https://github.com/tetratelabs/proxy-wasm-go-sdk/workflows/test/badge.svg)](https://github.com/tetratelabs/proxy-wasm-go-sdk/actions) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 The Go SDK for
  [Proxy-Wasm](https://github.com/proxy-wasm/spec), enabling developers to write Proxy-Wasm extensions in Go.
 
-proxy-wasm-go-sdk is powered by [TinyGo](https://tinygo.org/) and does not support the official Go compiler.
-
+This SDK is powered by [TinyGo](https://tinygo.org/) and does not support the official Go compiler.
 
 ```golang
 import (
@@ -42,46 +38,49 @@ func (ctx *metricHttpContext) OnHttpRequestHeaders(int, bool) types.Action {
 
 ## Requirements
 
-proxy-wasm-go-sdk depends on TinyGo's [WASI](https://github.com/WebAssembly/WASI) (WebAssembly System Interface) target
-which is introduced in [v0.16.0](https://github.com/tinygo-org/tinygo/releases/tag/v0.16.0).
+This SDK depends on TinyGo and leverages its [WASI](https://github.com/WebAssembly/WASI) (WebAssembly System Interface) target.
 
-Please follow the official instruction [here](https://tinygo.org/getting-started/).
-
+Please follow the official instruction [here](https://tinygo.org/getting-started/) for installing TinyGo.
 
 ### Compatible ABI / Envoy builds (tested on CI)
 
 | proxy-wasm-go-sdk| proxy-wasm ABI version |istio/proxyv2| Envoy upstream|
 |:-------------:|:-------------:|:-------------:|:-------------:|
 | main | 0.2.0| 1.9, 1.10 | 1.18 |
-| v0.1.1 | 0.2.0| 1.8, 1.9 | 1.17 |
-
+| v0.2.0 | 0.2.0| 1.8, 1.9 | 1.17 |
 
 ## Run examples
 
 build:
 
 ```bash
-make build.examples        # build all examples
+# Build all examples.
+make build.examples
 
-make build.example name=helloworld        # build a specific example
+# Build a specific example.
+make build.example name=helloworld
 ```
 
 run:
 
 ```bash
-make run name=helloworld # requires a locally installed Envoy binary
+# This requires you to have Envoy binary locally.
+make run name=helloworld
 ``` 
 
 ## SDK development
 
 ```bash
-make test # run local tests without running envoy processes
+# Run local tests without running envoy processes.
+make test
 
-## requires you to have Envoy binary locally
-make test.e2e # run e2e tests
+# Run all e2e tests.
+# This requires you to have Envoy binary locally.
+make test.e2e
 
-## requires you to have Envoy binary locally
-make test.e2e.single name=helloworld # run e2e tests
+# Run e2e tests for a specific example.
+# This requires you to have Envoy binary locally.
+make test.e2e.single name=helloworld
 ```
 
 ## Limitations and Considerations

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ make test.e2e.single name=helloworld
     with `-gc=none` option. This is the future TODO.
 - `recover` is [not implemented](https://github.com/tinygo-org/tinygo/issues/891) in TinyGo, and there's no way to prevent the WASM virtual machine from aborting.
 - Goroutine support
-    - In Tinygo, Goroutine is implmeneted through LLVM's coroutine (see [this blog post](https://aykevl.nl/2019/02/tinygo-goroutines)).
+    - In TinyGo, Goroutine is implmeneted through LLVM's coroutine (see [this blog post](https://aykevl.nl/2019/02/tinygo-goroutines)).
     - In Envoy, WASM modules are run in the event driven manner, and therefore the "scheduler" is not executed once the main function exits. 
         That means you cannot have the expected behavior of Goroutine as in ordinary host environments.
         - The question "How to deal with Goroutine in a thread local WASM VM executed in the event drive manner" has yet to be answered.

--- a/proxytest/http.go
+++ b/proxytest/http.go
@@ -47,7 +47,7 @@ func newHttpHostEmulator() *httpHostEmulator {
 	return host
 }
 
-// impl rawhostcall.ProxyWASMHost: delegated from hostEmulator
+// impl rawhostcall.ProxyWasmHost: delegated from hostEmulator
 func (h *httpHostEmulator) httpHostEmulatorProxyGetBufferBytes(bt types.BufferType, start int, maxSize int,
 	returnBufferData **byte, returnBufferSize *int) types.Status {
 	active := proxywasm.VMStateGetActiveContextID()
@@ -114,7 +114,7 @@ func (h *httpHostEmulator) httpHostEmulatorProxySetBufferBytes(bt types.BufferTy
 	}
 }
 
-// impl rawhostcall.ProxyWASMHost: delegated from hostEmulator
+// impl rawhostcall.ProxyWasmHost: delegated from hostEmulator
 func (h *httpHostEmulator) httpHostEmulatorProxyGetHeaderMapValue(mapType types.MapType, keyData *byte,
 	keySize int, returnValueData **byte, returnValueSize *int) types.Status {
 	key := proxywasm.RawBytePtrToString(keyData, keySize)
@@ -147,7 +147,7 @@ func (h *httpHostEmulator) httpHostEmulatorProxyGetHeaderMapValue(mapType types.
 	return types.StatusNotFound
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *httpHostEmulator) ProxyAddHeaderMapValue(mapType types.MapType, keyData *byte,
 	keySize int, valueData *byte, valueSize int) types.Status {
 
@@ -183,7 +183,7 @@ func addMapValue(base [][2]string, key, value string) [][2]string {
 	return append(base, [2]string{key, value})
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *httpHostEmulator) ProxyReplaceHeaderMapValue(mapType types.MapType, keyData *byte,
 	keySize int, valueData *byte, valueSize int) types.Status {
 	key := proxywasm.RawBytePtrToString(keyData, keySize)
@@ -206,7 +206,7 @@ func (h *httpHostEmulator) ProxyReplaceHeaderMapValue(mapType types.MapType, key
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func replaceMapValue(base [][2]string, key, value string) [][2]string {
 	for i, h := range base {
 		if h[0] == key {
@@ -218,7 +218,7 @@ func replaceMapValue(base [][2]string, key, value string) [][2]string {
 	return append(base, [2]string{key, value})
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *httpHostEmulator) ProxyRemoveHeaderMapValue(mapType types.MapType, keyData *byte, keySize int) types.Status {
 	key := proxywasm.RawBytePtrToString(keyData, keySize)
 	active := proxywasm.VMStateGetActiveContextID()
@@ -252,7 +252,7 @@ func removeHeaderMapValue(base [][2]string, key string) [][2]string {
 	return base
 }
 
-// impl rawhostcall.ProxyWASMHost: delegated from hostEmulator
+// impl rawhostcall.ProxyWasmHost: delegated from hostEmulator
 func (h *httpHostEmulator) httpHostEmulatorProxyGetHeaderMapPairs(mapType types.MapType, returnValueData **byte,
 	returnValueSize *int) types.Status {
 	active := proxywasm.VMStateGetActiveContextID()
@@ -277,7 +277,7 @@ func (h *httpHostEmulator) httpHostEmulatorProxyGetHeaderMapPairs(mapType types.
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *httpHostEmulator) ProxySetHeaderMapPairs(mapType types.MapType, mapData *byte, mapSize int) types.Status {
 	m := proxywasm.DeserializeMap(proxywasm.RawBytePtrToByteSlice(mapData, mapSize))
 	active := proxywasm.VMStateGetActiveContextID()
@@ -298,7 +298,7 @@ func (h *httpHostEmulator) ProxySetHeaderMapPairs(mapType types.MapType, mapData
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *httpHostEmulator) ProxyContinueStream(types.StreamType) types.Status {
 	active := proxywasm.VMStateGetActiveContextID()
 	stream := h.httpStreams[active]
@@ -306,7 +306,7 @@ func (h *httpHostEmulator) ProxyContinueStream(types.StreamType) types.Status {
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *httpHostEmulator) ProxySendLocalResponse(statusCode uint32,
 	statusCodeDetailData *byte, statusCodeDetailsSize int, bodyData *byte, bodySize int,
 	headersData *byte, headersSize int, grpcStatus int32) types.Status {

--- a/proxytest/network.go
+++ b/proxytest/network.go
@@ -37,7 +37,7 @@ func newNetworkHostEmulator() *networkHostEmulator {
 	return host
 }
 
-// impl rawhostcall.ProxyWASMHost: delegated from hostEmulator
+// impl rawhostcall.ProxyWasmHost: delegated from hostEmulator
 func (n *networkHostEmulator) networkHostEmulatorProxyGetBufferBytes(bt types.BufferType, start int, maxSize int,
 	returnBufferData **byte, returnBufferSize *int) types.Status {
 

--- a/proxytest/proxytest.go
+++ b/proxytest/proxytest.go
@@ -95,7 +95,7 @@ func NewHostEmulator(opt *EmulatorOption) HostEmulator {
 	}
 
 	hostMux.Lock() // acquire the lock of host emulation
-	rawhostcall.RegisterMockWASMHost(emulator)
+	rawhostcall.RegisterMockWasmHost(emulator)
 
 	// set up state
 	proxywasm.SetNewRootContext(opt.newRootContext)
@@ -118,7 +118,7 @@ func (*hostEmulator) Done() {
 	defer proxywasm.VMStateReset()
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *hostEmulator) ProxyGetBufferBytes(bt types.BufferType, start int, maxSize int,
 	returnBufferData **byte, returnBufferSize *int) types.Status {
 	switch bt {
@@ -142,7 +142,7 @@ func (h *hostEmulator) ProxySetBufferBytes(bt types.BufferType, start int, maxSi
 	}
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *hostEmulator) ProxyGetHeaderMapValue(mapType types.MapType, keyData *byte,
 	keySize int, returnValueData **byte, returnValueSize *int) types.Status {
 	switch mapType {
@@ -158,7 +158,7 @@ func (h *hostEmulator) ProxyGetHeaderMapValue(mapType types.MapType, keyData *by
 	}
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *hostEmulator) ProxyGetHeaderMapPairs(mapType types.MapType, returnValueData **byte,
 	returnValueSize *int) types.Status {
 	switch mapType {
@@ -172,36 +172,36 @@ func (h *hostEmulator) ProxyGetHeaderMapPairs(mapType types.MapType, returnValue
 	}
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *hostEmulator) ProxySetEffectiveContext(contextID uint32) types.Status {
 	h.effectiveContextID = contextID
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *hostEmulator) ProxySetProperty(*byte, int, *byte, int) types.Status {
 	panic("unimplemented")
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *hostEmulator) ProxyGetProperty(*byte, int, **byte, *int) types.Status {
 	log.Printf("ProxyGetProperty not implemented in the host emulator yet")
 	return 0
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *hostEmulator) ProxyResolveSharedQueue(vmIDData *byte, vmIDSize int, nameData *byte, nameSize int, returnID *uint32) types.Status {
 	log.Printf("ProxyResolveSharedQueue not implemented in the host emulator yet")
 	return 0
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *hostEmulator) ProxyCloseStream(streamType types.StreamType) types.Status {
 	log.Printf("ProxyCloseStream not implemented in the host emulator yet")
 	return 0
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (h *hostEmulator) ProxyDone() types.Status {
 	log.Printf("ProxyDone not implemented in the host emulator yet")
 	return 0

--- a/proxytest/root.go
+++ b/proxytest/root.go
@@ -85,7 +85,7 @@ func newRootHostEmulator(pluginConfiguration, vmConfiguration []byte) *rootHostE
 	return host
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxyLog(logLevel types.LogLevel, messageData *byte, messageSize int) types.Status {
 	str := proxywasm.RawBytePtrToString(messageData, messageSize)
 
@@ -94,13 +94,13 @@ func (r *rootHostEmulator) ProxyLog(logLevel types.LogLevel, messageData *byte, 
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxySetTickPeriodMilliseconds(period uint32) types.Status {
 	r.tickPeriod = period
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxyRegisterSharedQueue(nameData *byte, nameSize int, returnID *uint32) types.Status {
 	name := proxywasm.RawBytePtrToString(nameData, nameSize)
 	if id, ok := r.queueNameID[name]; ok {
@@ -115,7 +115,7 @@ func (r *rootHostEmulator) ProxyRegisterSharedQueue(nameData *byte, nameSize int
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxyDequeueSharedQueue(queueID uint32, returnValueData **byte, returnValueSize *int) types.Status {
 	queue, ok := r.queues[queueID]
 	if !ok {
@@ -133,7 +133,7 @@ func (r *rootHostEmulator) ProxyDequeueSharedQueue(queueID uint32, returnValueDa
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxyEnqueueSharedQueue(queueID uint32, valueData *byte, valueSize int) types.Status {
 	queue, ok := r.queues[queueID]
 	if !ok {
@@ -146,7 +146,7 @@ func (r *rootHostEmulator) ProxyEnqueueSharedQueue(queueID uint32, valueData *by
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxyGetSharedData(keyData *byte, keySize int,
 	returnValueData **byte, returnValueSize *int, returnCas *uint32) types.Status {
 	key := proxywasm.RawBytePtrToString(keyData, keySize)
@@ -162,7 +162,7 @@ func (r *rootHostEmulator) ProxyGetSharedData(keyData *byte, keySize int,
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxySetSharedData(keyData *byte, keySize int,
 	valueData *byte, valueSize int, cas uint32) types.Status {
 	key := proxywasm.RawBytePtrToString(keyData, keySize)
@@ -186,7 +186,7 @@ func (r *rootHostEmulator) ProxySetSharedData(keyData *byte, keySize int,
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxyDefineMetric(metricType types.MetricType,
 	metricNameData *byte, metricNameSize int, returnMetricIDPtr *uint32) types.Status {
 	name := proxywasm.RawBytePtrToString(metricNameData, metricNameSize)
@@ -201,7 +201,7 @@ func (r *rootHostEmulator) ProxyDefineMetric(metricType types.MetricType,
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxyIncrementMetric(metricID uint32, offset int64) types.Status {
 	val, ok := r.metricIDToValue[metricID]
 	if !ok {
@@ -212,7 +212,7 @@ func (r *rootHostEmulator) ProxyIncrementMetric(metricID uint32, offset int64) t
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxyRecordMetric(metricID uint32, value uint64) types.Status {
 	_, ok := r.metricIDToValue[metricID]
 	if !ok {
@@ -222,7 +222,7 @@ func (r *rootHostEmulator) ProxyRecordMetric(metricID uint32, value uint64) type
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxyGetMetric(metricID uint32, returnMetricValue *uint64) types.Status {
 	value, ok := r.metricIDToValue[metricID]
 	if !ok {
@@ -232,7 +232,7 @@ func (r *rootHostEmulator) ProxyGetMetric(metricID uint32, returnMetricValue *ui
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxyHttpCall(upstreamData *byte, upstreamSize int, headerData *byte, headerSize int, bodyData *byte,
 	bodySize int, trailersData *byte, trailersSize int, timeout uint32, calloutIDPtr *uint32) types.Status {
 	upstream := proxywasm.RawBytePtrToString(upstreamData, upstreamSize)
@@ -260,12 +260,12 @@ func (r *rootHostEmulator) ProxyHttpCall(upstreamData *byte, upstreamSize int, h
 	return types.StatusOK
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) RegisterForeignFunction(name string, f func([]byte) []byte) {
 	r.foreignFunctions[name] = f
 }
 
-// impl rawhostcall.ProxyWASMHost
+// impl rawhostcall.ProxyWasmHost
 func (r *rootHostEmulator) ProxyCallForeignFunction(funcNamePtr *byte, funcNameSize int, paramPtr *byte, paramSize int, returnData **byte, returnSize *int) types.Status {
 	funcName := proxywasm.RawBytePtrToString(funcNamePtr, funcNameSize)
 	param := proxywasm.RawBytePtrToByteSlice(paramPtr, paramSize)
@@ -284,7 +284,7 @@ func (r *rootHostEmulator) ProxyCallForeignFunction(funcNamePtr *byte, funcNameS
 	return types.StatusOK
 }
 
-// // impl rawhostcall.ProxyWASMHost: delegated from hostEmulator
+// // impl rawhostcall.ProxyWasmHost: delegated from hostEmulator
 func (r *rootHostEmulator) rootHostEmulatorProxyGetHeaderMapPairs(mapType types.MapType, returnValueData **byte, returnValueSize *int) types.Status {
 	res, ok := r.httpCalloutResponse[r.activeCalloutID]
 	if !ok {
@@ -306,7 +306,7 @@ func (r *rootHostEmulator) rootHostEmulatorProxyGetHeaderMapPairs(mapType types.
 	return types.StatusOK
 }
 
-// // impl rawhostcall.ProxyWASMHost: delegated from hostEmulator
+// // impl rawhostcall.ProxyWasmHost: delegated from hostEmulator
 func (r *rootHostEmulator) rootHostEmulatorProxyGetMapValue(mapType types.MapType, keyData *byte,
 	keySize int, returnValueData **byte, returnValueSize *int) types.Status {
 	res, ok := r.httpCalloutResponse[r.activeCalloutID]
@@ -338,7 +338,7 @@ func (r *rootHostEmulator) rootHostEmulatorProxyGetMapValue(mapType types.MapTyp
 	return types.StatusNotFound
 }
 
-// // impl rawhostcall.ProxyWASMHost: delegated from hostEmulator
+// // impl rawhostcall.ProxyWasmHost: delegated from hostEmulator
 func (r *rootHostEmulator) rootHostEmulatorProxyGetBufferBytes(bt types.BufferType, start int, maxSize int,
 	returnBufferData **byte, returnBufferSize *int) types.Status {
 	var buf []byte

--- a/proxywasm/abi_l7_test.go
+++ b/proxywasm/abi_l7_test.go
@@ -94,7 +94,7 @@ func Test_l7(t *testing.T) {
 func Test_proxyOnHttpCallResponse(t *testing.T) {
 	hostMutex.Lock()
 	defer hostMutex.Unlock()
-	rawhostcall.RegisterMockWASMHost(rawhostcall.DefaultProxyWAMSHost{})
+	rawhostcall.RegisterMockWasmHost(rawhostcall.DefaultProxyWAMSHost{})
 
 	var (
 		rootContextID uint32 = 1

--- a/proxywasm/abi_test_export.go
+++ b/proxywasm/abi_test_export.go
@@ -19,7 +19,7 @@ package proxywasm
 import "github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
 
 // this file exists only for proxytest package which is used with the `proxytest` build tag.
-//	Therefore, these functions are not included in a resulting WASM binary
+//	Therefore, these functions are not included in a resulting Wasm binary
 
 func ProxyOnVMStart(rootContextID uint32, vmConfigurationSize int) types.OnVMStartStatus {
 	return proxyOnVMStart(rootContextID, vmConfigurationSize)

--- a/proxywasm/hostcall_logging_test.go
+++ b/proxywasm/hostcall_logging_test.go
@@ -42,7 +42,7 @@ func TestHostCall_Logging(t *testing.T) {
 	defer hostMutex.Unlock()
 
 	t.Run("trace", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "trace",
@@ -52,7 +52,7 @@ func TestHostCall_Logging(t *testing.T) {
 	})
 
 	t.Run("tracef", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "trace: log",
@@ -62,7 +62,7 @@ func TestHostCall_Logging(t *testing.T) {
 	})
 
 	t.Run("debug", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "abc",
@@ -72,7 +72,7 @@ func TestHostCall_Logging(t *testing.T) {
 	})
 
 	t.Run("debugf", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "debug: log",
@@ -82,7 +82,7 @@ func TestHostCall_Logging(t *testing.T) {
 	})
 
 	t.Run("info", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "info",
@@ -92,7 +92,7 @@ func TestHostCall_Logging(t *testing.T) {
 	})
 
 	t.Run("infof", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "info: log: 10",
@@ -102,7 +102,7 @@ func TestHostCall_Logging(t *testing.T) {
 	})
 
 	t.Run("warn", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "warn",
@@ -112,7 +112,7 @@ func TestHostCall_Logging(t *testing.T) {
 	})
 
 	t.Run("warnf", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "warn: log: 10",
@@ -122,7 +122,7 @@ func TestHostCall_Logging(t *testing.T) {
 	})
 
 	t.Run("error", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "error",
@@ -132,7 +132,7 @@ func TestHostCall_Logging(t *testing.T) {
 	})
 
 	t.Run("warnf", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "warn: log: 10",
@@ -142,7 +142,7 @@ func TestHostCall_Logging(t *testing.T) {
 	})
 
 	t.Run("critical", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "critical error",
@@ -152,7 +152,7 @@ func TestHostCall_Logging(t *testing.T) {
 	})
 
 	t.Run("criticalf", func(t *testing.T) {
-		rawhostcall.RegisterMockWASMHost(logHost{
+		rawhostcall.RegisterMockWasmHost(logHost{
 			DefaultProxyWAMSHost: rawhostcall.DefaultProxyWAMSHost{},
 			t:                    t,
 			expMessage:           "critical: log: 10",

--- a/proxywasm/hostcall_metric_test.go
+++ b/proxywasm/hostcall_metric_test.go
@@ -23,14 +23,14 @@ import (
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
 )
 
-type metricProxyWASMHost struct {
+type metricProxyWasmHost struct {
 	rawhostcall.DefaultProxyWAMSHost
 	idToValue map[uint32]uint64
 	idToType  map[uint32]types.MetricType
 	nameToID  map[string]uint32
 }
 
-func (m metricProxyWASMHost) ProxyDefineMetric(metricType types.MetricType,
+func (m metricProxyWasmHost) ProxyDefineMetric(metricType types.MetricType,
 	metricNameData *byte, metricNameSize int, returnMetricIDPtr *uint32) types.Status {
 	name := RawBytePtrToString(metricNameData, metricNameSize)
 	id, ok := m.nameToID[name]
@@ -44,7 +44,7 @@ func (m metricProxyWASMHost) ProxyDefineMetric(metricType types.MetricType,
 	return types.StatusOK
 }
 
-func (m metricProxyWASMHost) ProxyIncrementMetric(metricID uint32, offset int64) types.Status {
+func (m metricProxyWasmHost) ProxyIncrementMetric(metricID uint32, offset int64) types.Status {
 	val, ok := m.idToValue[metricID]
 	if !ok {
 		return types.StatusBadArgument
@@ -54,7 +54,7 @@ func (m metricProxyWASMHost) ProxyIncrementMetric(metricID uint32, offset int64)
 	return types.StatusOK
 }
 
-func (m metricProxyWASMHost) ProxyRecordMetric(metricID uint32, value uint64) types.Status {
+func (m metricProxyWasmHost) ProxyRecordMetric(metricID uint32, value uint64) types.Status {
 	_, ok := m.idToValue[metricID]
 	if !ok {
 		return types.StatusBadArgument
@@ -63,7 +63,7 @@ func (m metricProxyWASMHost) ProxyRecordMetric(metricID uint32, value uint64) ty
 	return types.StatusOK
 }
 
-func (m metricProxyWASMHost) ProxyGetMetric(metricID uint32, returnMetricValue *uint64) types.Status {
+func (m metricProxyWasmHost) ProxyGetMetric(metricID uint32, returnMetricValue *uint64) types.Status {
 	value, ok := m.idToValue[metricID]
 	if !ok {
 		return types.StatusBadArgument
@@ -73,7 +73,7 @@ func (m metricProxyWASMHost) ProxyGetMetric(metricID uint32, returnMetricValue *
 }
 
 func TestHostCall_Metric(t *testing.T) {
-	host := metricProxyWASMHost{
+	host := metricProxyWasmHost{
 		rawhostcall.DefaultProxyWAMSHost{},
 		map[uint32]uint64{},
 		map[uint32]types.MetricType{},
@@ -81,7 +81,7 @@ func TestHostCall_Metric(t *testing.T) {
 	}
 	hostMutex.Lock()
 	defer hostMutex.Unlock()
-	rawhostcall.RegisterMockWASMHost(host)
+	rawhostcall.RegisterMockWasmHost(host)
 
 	t.Run("counter", func(t *testing.T) {
 		for _, c := range []struct {

--- a/proxywasm/rawhostcall/rawhostcall_mock.go
+++ b/proxywasm/rawhostcall/rawhostcall_mock.go
@@ -18,13 +18,13 @@ package rawhostcall
 
 import "github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
 
-var currentHost ProxyWASMHost
+var currentHost ProxyWasmHost
 
-func RegisterMockWASMHost(host ProxyWASMHost) {
+func RegisterMockWasmHost(host ProxyWasmHost) {
 	currentHost = host
 }
 
-type ProxyWASMHost interface {
+type ProxyWasmHost interface {
 	ProxyLog(logLevel types.LogLevel, messageData *byte, messageSize int) types.Status
 	ProxySetProperty(pathData *byte, pathSize int, valueData *byte, valueSize int) types.Status
 	ProxyGetProperty(pathData *byte, pathSize int, returnValueData **byte, returnValueSize *int) types.Status
@@ -58,7 +58,7 @@ type ProxyWASMHost interface {
 
 type DefaultProxyWAMSHost struct{}
 
-var _ ProxyWASMHost = DefaultProxyWAMSHost{}
+var _ ProxyWasmHost = DefaultProxyWAMSHost{}
 
 func (d DefaultProxyWAMSHost) ProxyLog(logLevel types.LogLevel, messageData *byte, messageSize int) types.Status {
 	return 0


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>