### PR TITLE
Fix README.md: stop maintain Envoy/Istio/Proxy-Wasm Go SDK tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,12 @@ make build.example name=helloworld
 make run name=helloworld
 ```
 
-## Compatible Envoy builds (End-to-End tested)
+## Compatible Envoy builds
 
 Envoy is the first host side implementation of Proxy-Wasm ABI, 
-and we run end-to-end tests with multiple Envoy versions in order to verify Proxy-Wasm Go SDK works as expected.
+and we run end-to-end tests with multiple versions of Envoy and Envoy-based [istio/proxy](https://github.com/istio/proxy) in order to verify Proxy-Wasm Go SDK works as expected.
 
-| Istio| Envoy |
-|:-------------:|:-------------:|
-|  1.9, 1.10 | 1.18 |
+Please refer to [.github/workflows/workflow.yaml](.github/workflows/workflow.yaml) for which version is used for End-to-End tests.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ make run name=helloworld
 Envoy is the first host side implementation of Proxy-Wasm ABI, 
 and we run end-to-end tests with multiple versions of Envoy and Envoy-based [istio/proxy](https://github.com/istio/proxy) in order to verify Proxy-Wasm Go SDK works as expected.
 
-Please refer to [.github/workflows/workflow.yaml](.github/workflows/workflow.yaml) for which version is used for End-to-End tests.
+Please refer to [workflow.yaml](.github/workflows/workflow.yaml) for which version is used for End-to-End tests.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,15 +37,14 @@ make build.example name=helloworld
 make run name=helloworld
 ```
 
-## Compatible Envoy builds (tested on CI)
+## Compatible Envoy builds (End-to-End tested)
 
 Envoy is the first host side implementation of Proxy-Wasm ABI, 
 and we run end-to-end tests with multiple Envoy versions in order to verify Proxy-Wasm Go SDK works as expected.
 
-| proxy-wasm-go-sdk| istio/proxyv2| Envoy upstream|
-|:-------------:|:-------------:|:-------------:|
-| main | 1.9, 1.10 | 1.18 |
-| v0.3.0 | 1.9, 1.10 | 1.18 |
+| Istio| Envoy |
+|:-------------:|:-------------:|
+|  1.9, 1.10 | 1.18 |
 
 ## Contributing
 


### PR DESCRIPTION
Occasionally I forgot to update accordingly so now remove this from README.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>