### PR TITLE
Add a make rule to run the e2e tests on the docker environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ build.examples:
 test:
 	go test -tags=proxytest $(shell go list ./... | grep -v e2e)
 
-test.e2e: build.examples
+test.e2e:
 	go test -v ./e2e -count=1
 
 test.e2e.single:
 	go test -v ./e2e -run '/${name}' -count=1
 
-test.e2e.docker:
+test.e2e.docker: build.examples
 	docker-compose -f ./e2e/docker/docker-compose.yml run --rm sandbox $(MAKE) test.e2e
 
 run:

--- a/e2e/docker/Dockerfile
+++ b/e2e/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM envoyproxy/envoy:v1.18.3 AS envoy
+WORKDIR /app
+RUN cp $(which envoy) ./envoy
+
+FROM golang:1.16 AS go
+
+FROM tinygo/tinygo:0.18.0
+ENV PATH $PATH:/usr/local/go/bin
+RUN apt-get clean && \
+    apt-get update && \
+    apt-get install -y make
+COPY --from=envoy /app/envoy /usr/local/bin
+COPY --from=go /usr/local/go /usr/local/go

--- a/e2e/docker/docker-compose.yml
+++ b/e2e/docker/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  sandbox:
+    build:
+      context: .
+    volumes:
+      - ../../:/app
+    working_dir: /app
+


### PR DESCRIPTION
## Summary
This PR introduces docker environments to execute e2e tests easily on the local machines.