### PR TITLE
Push Wasm images of examples to ghcr.

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -81,13 +81,16 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
 
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Fetch built examples
         uses: actions/cache@v2
         with:
           path: examples
           key: examples-${{ hashFiles('examples/**', 'proxywasm/**') }}
 
-      - name: Run e2e test
+      - name: Build/Push
         run: make wasm_image.build_push
 
   e2e-tests:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -70,6 +70,26 @@ jobs:
         if: steps.cache-built-examples.outputs.cache-hit != 'true'
         run: make build.examples
 
+  build-push-example-wasm-image:
+    name: Build/Push Wasm Images of examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Fetch built examples
+        uses: actions/cache@v2
+        with:
+          path: examples
+          key: examples-${{ hashFiles('examples/**', 'proxywasm/**') }}
+
+      - name: Run e2e test
+        run: make wasm_image.build_push
+
   e2e-tests:
     strategy:
       fail-fast: false

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -73,6 +73,7 @@ jobs:
   build-push-example-wasm-image:
     name: Build/Push Wasm Images of examples
     runs-on: ubuntu-latest
+    needs: [build-examples]
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -104,7 +105,7 @@ jobs:
           "istio/proxyv2:1.10.0",
         ]
     name: E2E Test (${{ matrix.image }})
-    needs: build-examples
+    needs: [build-examples]
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}

--- a/examples/wasm-image.Dockerfile
+++ b/examples/wasm-image.Dockerfile
@@ -1,0 +1,6 @@
+# Dockerfile for building "compat" variant of Wasm Image Specification.
+# https://github.com/solo-io/wasm/blob/master/spec/spec-compat.md
+FROM scratch
+
+ARG WASM_BINARY_PATH
+COPY ${WASM_BINARY_PATH} ./plugin.wasm


### PR DESCRIPTION
resolves #200 and images should be available here [ghcr.io/tetratelabs/proxy-wasm-go-sdk-examples:${example name}](https://github.com/orgs/tetratelabs/packages/container/package/proxy-wasm-go-sdk-examples) as docker images

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>