### PR TITLE
Allow specifying gRPC status on SendHttpResponse.

### DIFF
--- a/examples/http_auth_random/main.go
+++ b/examples/http_auth_random/main.go
@@ -112,7 +112,7 @@ func httpCallResponseCallback(numHeaders, bodySize, numTrailers int) {
 	proxywasm.LogInfo(body)
 	if err := proxywasm.SendHttpResponse(403, [][2]string{
 		{"powered-by", "proxy-wasm-go-sdk!!"},
-	}, []byte(body)); err != nil {
+	}, []byte(body), -1); err != nil {
 		proxywasm.LogErrorf("failed to send local response: %v", err)
 		proxywasm.ResumeHttpRequest()
 	}

--- a/examples/http_body/main.go
+++ b/examples/http_body/main.go
@@ -76,7 +76,7 @@ type setBodyContext struct {
 // Override types.DefaultHttpContext.
 func (ctx *setBodyContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
 	if _, err := proxywasm.GetHttpRequestHeader("content-length"); err != nil {
-		if err := proxywasm.SendHttpResponse(400, nil, []byte("content must be provided")); err != nil {
+		if err := proxywasm.SendHttpResponse(400, nil, []byte("content must be provided"), -1); err != nil {
 			panic(err)
 		}
 		return types.ActionPause
@@ -146,7 +146,7 @@ func (ctx *echoBodyContext) OnHttpRequestBody(bodySize int, endOfStream bool) ty
 
 	// Send the request body as the response body.
 	body, _ := proxywasm.GetHttpRequestBody(0, ctx.totalRequestBodySize)
-	if err := proxywasm.SendHttpResponse(200, nil, body); err != nil {
+	if err := proxywasm.SendHttpResponse(200, nil, body, -1); err != nil {
 		panic(err)
 	}
 	return types.ActionPause

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -477,7 +477,8 @@ func ResumeHttpResponse() error {
 // to override the already sent headers.
 // types.Action.Pause *must* be returned after invoking this function, in order to stop further processing
 // of original http request/response.
-func SendHttpResponse(statusCode uint32, headers [][2]string, body []byte) error {
+// Note that gRPCStatus can be set to -1 if this is a not gRPC stream.
+func SendHttpResponse(statusCode uint32, headers [][2]string, body []byte, gRPCStatus int32) error {
 	shs := internal.SerializeMap(headers)
 	var bp *byte
 	if len(body) > 0 {
@@ -488,7 +489,7 @@ func SendHttpResponse(statusCode uint32, headers [][2]string, body []byte) error
 	return internal.StatusToError(
 		internal.ProxySendLocalResponse(
 			statusCode, nil, 0,
-			bp, len(body), hp, hl, -1,
+			bp, len(body), hp, hl, gRPCStatus,
 		),
 	)
 }


### PR DESCRIPTION
resolves #209

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>