### PR TITLE
test: use prometheus endpoint for metrics test.

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -182,14 +182,14 @@ func Test_metrics(t *testing.T) {
 		return count == 10
 	}, 5*time.Second, time.Millisecond, "Endpoint not healthy.")
 	require.Eventually(t, func() bool {
-		res, err := http.Get("http://localhost:8001/stats")
+		res, err := http.Get("http://localhost:8001/stats/prometheus")
 		if err != nil {
 			return false
 		}
 		defer res.Body.Close()
 		raw, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
-		return checkMessage(string(raw), []string{fmt.Sprintf("proxy_wasm_go.request_counter: %d", count)}, nil)
+		return checkMessage(string(raw), []string{fmt.Sprintf("proxy_wasm_go_request_counter{} %d", count)}, nil)
 	}, 5*time.Second, time.Millisecond, "Expected stats not found")
 }
 

--- a/examples/metrics/README.md
+++ b/examples/metrics/README.md
@@ -17,3 +17,9 @@ wasm log: incremented
 wasm log: previous value of proxy_wasm_go.request_counter: 5
 wasm log: incremented
 ```
+
+```
+$ curl -s 'localhost:8001/stats/prometheus'| grep proxy
+# TYPE proxy_wasm_go_request_counter counter
+proxy_wasm_go_request_counter{} 5
+```


### PR DESCRIPTION
Following the change in the Envoy upstream: https://github.com/envoyproxy/envoy/pull/17357

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>