### PR TITLE
Add an example of JWT authorization

### DIFF
--- a/examples/http_jwt_auth/README.md
+++ b/examples/http_jwt_auth/README.md
@@ -1,4 +1,4 @@
-## http_authz
+## http_jwt_auth
 
 This example demonstrates how to authorize the incoming request depending on jwt token.
 

--- a/examples/http_jwt_auth/README.md
+++ b/examples/http_jwt_auth/README.md
@@ -1,0 +1,10 @@
+## http_authz
+
+This example demonstrates how to authorize the incoming request depending on jwt token.
+
+In this example, the jwt token should be signed in HMAC256 (HMAC-SHA256). 
+
+```
+$ curl -XGET localhost:18000 -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M"
+example body
+```

--- a/examples/http_jwt_auth/envoy.yaml
+++ b/examples/http_jwt_auth/envoy.yaml
@@ -1,0 +1,89 @@
+static_resources:
+  listeners:
+    - name: authz
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 18000
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: web_service
+                http_filters:
+                  - name: envoy.filters.http.wasm
+                    typed_config:
+                      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+                      type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+                      value:
+                        config:
+                          vm_config:
+                            runtime: "envoy.wasm.runtime.v8"
+                            code:
+                              local:
+                                filename: "./examples/http_jwt_auth/main.go.wasm"
+                  - name: envoy.filters.http.router
+
+    - name: staticreply
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 8099
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          direct_response:
+                            status: 200
+                            body:
+                              inline_string: "example body\n"
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config: {}
+
+  clusters:
+    - name: web_service
+      connect_timeout: 0.25s
+      type: STATIC
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: mock_service
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8099
+
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/http_jwt_auth/main.go
+++ b/examples/http_jwt_auth/main.go
@@ -109,7 +109,7 @@ func verifyToken(token string) (bool, error) {
 	}
 	unsignedToken := token[:sepIdx]
 	signature, err := base64.RawURLEncoding.DecodeString(token[sepIdx+1:])
-	if err != nil { // invalid base64 data
+	if err != nil {
 		return false, err
 	}
 	mac := hmac.New(sha256.New, []byte(secretKey))

--- a/examples/http_jwt_auth/main.go
+++ b/examples/http_jwt_auth/main.go
@@ -75,7 +75,7 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 
 	proxywasm.LogInfof("authorization token: %s", authorization)
 
-	// Validate header format
+	// Validate header format.
 	slice := strings.Fields(authorization)
 	if len(slice) != 2 || slice[0] != "Bearer" {
 		if err := proxywasm.SendHttpResponse(400, nil, []byte("invalid authorization header"), -1); err != nil {

--- a/examples/http_jwt_auth/main.go
+++ b/examples/http_jwt_auth/main.go
@@ -84,7 +84,7 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 		return types.ActionPause
 	}
 
-	// Verify token
+	// Verify token.
 	ok, err := verifyToken(slice[1])
 	if err != nil {
 		proxywasm.LogWarnf("failed to verify token with an error: %s", err)

--- a/examples/http_jwt_auth/main.go
+++ b/examples/http_jwt_auth/main.go
@@ -1,0 +1,137 @@
+// Copyright 2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+const (
+	// The secret key used to sign the JWT token.
+	secretKey = "secret"
+	// tick period in milliseconds.
+	tickMilliseconds uint32 = 100
+)
+
+func main() {
+	proxywasm.SetVMContext(&vmContext{})
+}
+
+type vmContext struct {
+	// Embed the default VM context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultVMContext
+}
+
+// Override types.DefaultVMContext.
+func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &pluginContext{contextID: contextID}
+}
+
+type pluginContext struct {
+	// Embed the default plugin context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultPluginContext
+	contextID uint32
+}
+
+// Override types.DefaultPluginContext.
+func (ctx *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
+	return &httpContext{contextID: contextID}
+}
+
+// Override types.DefaultPluginContext.
+func (ctx *pluginContext) OnPluginStart(pluginConfigurationSize int) types.OnPluginStartStatus {
+	// Set tick period. OnTick is called every tick period.
+	if err := proxywasm.SetTickPeriodMilliSeconds(tickMilliseconds); err != nil {
+		proxywasm.LogCriticalf("failed to set tick period: %v", err)
+	}
+
+	return types.OnPluginStartStatusOK
+}
+
+// Override types.DefaultPluginContext.
+func (ctx *pluginContext) OnTick() {
+	// These lines are used for observing the memory stability during the e2e test.
+	// TODO(musaprg): split this into another package and import it.
+	// 				  These lines are only used for testing, which should be separated from example code.
+	t := time.Now().UnixNano()
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	proxywasm.LogInfof("[memstat][contextID=%d][unixnanotime=%d] heap size: in-use / reserved = %d / %d bytes", ctx.contextID, t, mem.HeapInuse, mem.HeapSys)
+}
+
+type httpContext struct {
+	// Embed the default plugin context
+	// so that you don't need to reimplement all the methods by yourself.
+	types.DefaultHttpContext
+	contextID uint32
+}
+
+// Override types.DefaultHttpContext.
+func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	authorization, err := proxywasm.GetHttpRequestHeader("Authorization")
+	if err != nil {
+		if err := proxywasm.SendHttpResponse(400, nil, []byte("authorization header must be provided"), -1); err != nil {
+			panic(err)
+		}
+		return types.ActionPause
+	}
+
+	proxywasm.LogInfof("authorization token: %s", authorization)
+
+	// Validate format and verify token.
+	slice := strings.Fields(authorization)
+	if len(slice) != 2 || slice[0] != "Bearer" || !verifyToken(slice[1]) {
+		if err := proxywasm.SendHttpResponse(401, nil, []byte("invalid token"), -1); err != nil {
+			panic(err)
+		}
+		return types.ActionPause
+	}
+
+	proxywasm.LogInfof("request authorized!")
+
+	return types.ActionContinue
+}
+
+// Override types.DefaultHttpContext.
+func (ctx *httpContext) OnHttpStreamDone() {
+	proxywasm.LogInfof("%d finished", ctx.contextID)
+}
+
+// verifyToken checks if the JWT token is valid.
+func verifyToken(token string) bool {
+	slice := strings.Split(token, ".")
+	if len(slice) != 3 {
+		return false
+	}
+	unsignedToken := strings.Join(slice[:2], ".")
+	signature, err := base64.RawURLEncoding.DecodeString(slice[2])
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secretKey))
+	mac.Write([]byte(unsignedToken))
+	expectedSignature := mac.Sum(nil)
+	return hmac.Equal(signature, expectedSignature)
+}

--- a/examples/http_jwt_auth/main.go
+++ b/examples/http_jwt_auth/main.go
@@ -18,9 +18,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"runtime"
 	"strings"
-	"time"
 
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
@@ -29,8 +27,6 @@ import (
 const (
 	// The secret key used to sign the JWT token.
 	secretKey = "secret"
-	// tick period in milliseconds.
-	tickMilliseconds uint32 = 100
 )
 
 func main() {
@@ -62,23 +58,7 @@ func (ctx *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
 
 // Override types.DefaultPluginContext.
 func (ctx *pluginContext) OnPluginStart(pluginConfigurationSize int) types.OnPluginStartStatus {
-	// Set tick period. OnTick is called every tick period.
-	if err := proxywasm.SetTickPeriodMilliSeconds(tickMilliseconds); err != nil {
-		proxywasm.LogCriticalf("failed to set tick period: %v", err)
-	}
-
 	return types.OnPluginStartStatusOK
-}
-
-// Override types.DefaultPluginContext.
-func (ctx *pluginContext) OnTick() {
-	// These lines are used for observing the memory stability during the e2e test.
-	// TODO(musaprg): split this into another package and import it.
-	// 				  These lines are only used for testing, which should be separated from example code.
-	t := time.Now().UnixNano()
-	var mem runtime.MemStats
-	runtime.ReadMemStats(&mem)
-	proxywasm.LogInfof("[memstat][contextID=%d][unixnanotime=%d] heap size: in-use / reserved = %d / %d bytes", ctx.contextID, t, mem.HeapInuse, mem.HeapSys)
 }
 
 type httpContext struct {

--- a/examples/http_jwt_auth/main.go
+++ b/examples/http_jwt_auth/main.go
@@ -75,9 +75,21 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 
 	proxywasm.LogInfof("authorization token: %s", authorization)
 
-	// Validate format and verify token.
+	// Validate header format
 	slice := strings.Fields(authorization)
-	if len(slice) != 2 || slice[0] != "Bearer" || !verifyToken(slice[1]) {
+	if len(slice) != 2 || slice[0] != "Bearer" {
+		if err := proxywasm.SendHttpResponse(400, nil, []byte("invalid authorization header"), -1); err != nil {
+			panic(err)
+		}
+		return types.ActionPause
+	}
+
+	// Verify token
+	ok, err := verifyToken(slice[1])
+	if err != nil {
+		proxywasm.LogWarnf("failed to verify token with an error: %s", err)
+	}
+	if !ok {
 		if err := proxywasm.SendHttpResponse(401, nil, []byte("invalid token"), -1); err != nil {
 			panic(err)
 		}
@@ -90,15 +102,18 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 }
 
 // verifyToken checks if the JWT token is valid.
-func verifyToken(token string) bool {
+func verifyToken(token string) (bool, error) {
 	sepIdx := strings.LastIndex(token, ".")
+	if sepIdx == -1 {
+		return false, nil
+	}
 	unsignedToken := token[:sepIdx]
 	signature, err := base64.RawURLEncoding.DecodeString(token[sepIdx+1:])
-	if err != nil {
-		return false
+	if err != nil { // invalid base64 data
+		return false, err
 	}
 	mac := hmac.New(sha256.New, []byte(secretKey))
 	mac.Write([]byte(unsignedToken))
 	expectedSignature := mac.Sum(nil)
-	return hmac.Equal(signature, expectedSignature)
+	return hmac.Equal(signature, expectedSignature), nil
 }

--- a/examples/http_jwt_auth/main.go
+++ b/examples/http_jwt_auth/main.go
@@ -91,12 +91,9 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 
 // verifyToken checks if the JWT token is valid.
 func verifyToken(token string) bool {
-	slice := strings.Split(token, ".")
-	if len(slice) != 3 {
-		return false
-	}
-	unsignedToken := strings.Join(slice[:2], ".")
-	signature, err := base64.RawURLEncoding.DecodeString(slice[2])
+	sepIdx := strings.LastIndex(token, ".")
+	unsignedToken := token[:sepIdx]
+	signature, err := base64.RawURLEncoding.DecodeString(token[sepIdx+1:])
 	if err != nil {
 		return false
 	}

--- a/examples/http_jwt_auth/main.go
+++ b/examples/http_jwt_auth/main.go
@@ -56,11 +56,6 @@ func (ctx *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
 	return &httpContext{contextID: contextID}
 }
 
-// Override types.DefaultPluginContext.
-func (ctx *pluginContext) OnPluginStart(pluginConfigurationSize int) types.OnPluginStartStatus {
-	return types.OnPluginStartStatusOK
-}
-
 type httpContext struct {
 	// Embed the default plugin context
 	// so that you don't need to reimplement all the methods by yourself.
@@ -92,11 +87,6 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 	proxywasm.LogInfof("request authorized!")
 
 	return types.ActionContinue
-}
-
-// Override types.DefaultHttpContext.
-func (ctx *httpContext) OnHttpStreamDone() {
-	proxywasm.LogInfof("%d finished", ctx.contextID)
 }
 
 // verifyToken checks if the JWT token is valid.

--- a/examples/http_jwt_auth/main_test.go
+++ b/examples/http_jwt_auth/main_test.go
@@ -131,7 +131,7 @@ func TestHttpJwtAuth_OnHttpRequestHeaders(t *testing.T) {
 				require.Equal(t, uint32(401), localResponse.StatusCode)
 				require.Equal(t, "invalid token", string(localResponse.Data))
 
-				// Call OnHttpStreamDone
+				// Call OnHttpStreamDone.
 				host.CompleteHttpContext(id)
 			})
 		}

--- a/examples/http_jwt_auth/main_test.go
+++ b/examples/http_jwt_auth/main_test.go
@@ -60,7 +60,7 @@ func TestHttpJwtAuth_OnHttpRequestHeaders(t *testing.T) {
 		require.Equal(t, uint32(400), localResponse.StatusCode)
 		require.Equal(t, "authorization header must be provided", string(localResponse.Data))
 
-		// Call OnHttpStreamDone
+		// Call OnHttpStreamDone.
 		host.CompleteHttpContext(id)
 	})
 

--- a/examples/http_jwt_auth/main_test.go
+++ b/examples/http_jwt_auth/main_test.go
@@ -42,10 +42,6 @@ func TestHttpJwtAuth_OnHttpRequestHeaders(t *testing.T) {
 
 		// Call OnHttpStreamDone
 		host.CompleteHttpContext(id)
-
-		// Check Envoy logs.
-		logs := host.GetInfoLogs()
-		require.Contains(t, logs, fmt.Sprintf("%d finished", id))
 	})
 
 	t.Run("400 response", func(t *testing.T) {
@@ -66,10 +62,6 @@ func TestHttpJwtAuth_OnHttpRequestHeaders(t *testing.T) {
 
 		// Call OnHttpStreamDone
 		host.CompleteHttpContext(id)
-
-		// Check Envoy logs.
-		logs := host.GetInfoLogs()
-		require.Contains(t, logs, fmt.Sprintf("%d finished", id))
 	})
 
 	t.Run("401 response for invalid token", func(t *testing.T) {
@@ -92,9 +84,5 @@ func TestHttpJwtAuth_OnHttpRequestHeaders(t *testing.T) {
 
 		// Call OnHttpStreamDone
 		host.CompleteHttpContext(id)
-
-		// Check Envoy logs.
-		logs := host.GetInfoLogs()
-		require.Contains(t, logs, fmt.Sprintf("%d finished", id))
 	})
 }

--- a/examples/http_jwt_auth/main_test.go
+++ b/examples/http_jwt_auth/main_test.go
@@ -105,11 +105,11 @@ func TestHttpJwtAuth_OnHttpRequestHeaders(t *testing.T) {
 			name  string
 			token string
 		}{
-			{"invalid token with no dot", "invalidtoken"},
-			{"invalid token with one dot", "invalid.token"},
-			{"invalid token with two dot", "invalid.token.hoge"},
-			{"invalid token with non-base64 encoded signature", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.hogefugafoo"},
-			{"invalid token with base64 encoded signature", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.aG9nZWZ1Z2Fmb28K"},
+			{"no dot", "invalidtoken"},
+			{"one dot", "invalid.token"},
+			{"two dot", "invalid.token.hoge"},
+			{"non-base64 encoded signature", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.hogefugafoo"},
+			{"base64 encoded signature", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.aG9nZWZ1Z2Fmb28K"},
 		}
 
 		for _, tc := range testCases {

--- a/examples/http_jwt_auth/main_test.go
+++ b/examples/http_jwt_auth/main_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	// sampleJwtToken is a sample JWT token which is already signed with secret key "secret".
+	// A sample JWT token which is already signed with secret key "secret".
 	sampleJwtToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M`
 )
 

--- a/examples/http_jwt_auth/main_test.go
+++ b/examples/http_jwt_auth/main_test.go
@@ -94,7 +94,7 @@ func TestHttpJwtAuth_OnHttpRequestHeaders(t *testing.T) {
 				require.Equal(t, uint32(400), localResponse.StatusCode)
 				require.Equal(t, "invalid authorization header", string(localResponse.Data))
 
-				// Call OnHttpStreamDone
+				// Call OnHttpStreamDone.
 				host.CompleteHttpContext(id)
 			})
 		}

--- a/examples/http_jwt_auth/main_test.go
+++ b/examples/http_jwt_auth/main_test.go
@@ -1,0 +1,100 @@
+// These tests are supposed to run with `proxytest` build tag, and this way we can leverage the testing framework in "proxytest" package.
+// The framework emulates the expected behavior of Envoyproxy, and you can test your extensions without running Envoy and with
+// the standard Go CLI. To run tests, simply run
+// go test -tags=proxytest ./...
+
+//go:build proxytest
+// +build proxytest
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+const (
+	// sampleJwtToken is a sample JWT token which is already signed with secret key "secret".
+	sampleJwtToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M`
+)
+
+func TestHttpJwtAuth_OnHttpRequestHeaders(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithVMContext(&vmContext{})
+	host, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	t.Run("success authorization", func(t *testing.T) {
+		// Create http context.
+		id := host.InitializeHttpContext()
+
+		// Call OnRequestHeaders.
+		action := host.CallOnRequestHeaders(id, [][2]string{
+			{"Authorization", fmt.Sprintf("Bearer %s", sampleJwtToken)},
+		}, false)
+
+		// Must be continued.
+		require.Equal(t, types.ActionContinue, action)
+
+		// Call OnHttpStreamDone
+		host.CompleteHttpContext(id)
+
+		// Check Envoy logs.
+		logs := host.GetInfoLogs()
+		require.Contains(t, logs, fmt.Sprintf("%d finished", id))
+	})
+
+	t.Run("400 response", func(t *testing.T) {
+		// Create http context.
+		id := host.InitializeHttpContext()
+
+		// Call OnRequestHeaders.
+		action := host.CallOnRequestHeaders(id, nil, false)
+
+		// Must be paused.
+		require.Equal(t, types.ActionPause, action)
+
+		// Check the local response.
+		localResponse := host.GetSentLocalResponse(id)
+		require.NotNil(t, localResponse)
+		require.Equal(t, uint32(400), localResponse.StatusCode)
+		require.Equal(t, "authorization header must be provided", string(localResponse.Data))
+
+		// Call OnHttpStreamDone
+		host.CompleteHttpContext(id)
+
+		// Check Envoy logs.
+		logs := host.GetInfoLogs()
+		require.Contains(t, logs, fmt.Sprintf("%d finished", id))
+	})
+
+	t.Run("401 response for invalid token", func(t *testing.T) {
+		// Create http context.
+		id := host.InitializeHttpContext()
+
+		// Call OnRequestHeaders.
+		action := host.CallOnRequestHeaders(id, [][2]string{
+			{"Authorization", "invalidtoken"},
+		}, false)
+
+		// Must be paused.
+		require.Equal(t, types.ActionPause, action)
+
+		// Check the local response.
+		localResponse := host.GetSentLocalResponse(id)
+		require.NotNil(t, localResponse)
+		require.Equal(t, uint32(401), localResponse.StatusCode)
+		require.Equal(t, "invalid token", string(localResponse.Data))
+
+		// Call OnHttpStreamDone
+		host.CompleteHttpContext(id)
+
+		// Check Envoy logs.
+		logs := host.GetInfoLogs()
+		require.Contains(t, logs, fmt.Sprintf("%d finished", id))
+	})
+}


### PR DESCRIPTION
Signed-off-by: Kotaro Inoue <k.musaino@gmail.com>

This PR adds a simple example of JWT authorization.
The JWT token used in this example is expected to be signed in HMAC256 (HMAC-SHA256).