### PR TITLE
Initial rate limiting examples with Istio API

### DIFF
--- a/examples/istio_rate_limiting/README.md
+++ b/examples/istio_rate_limiting/README.md
@@ -1,0 +1,36 @@
+# Istio Wasm Demo for Rate Limiting
+
+Istio 1.12 release introduces new Wasm Extension API. This folder contains a sample application of
+implementing rate limiting in Golang, and deploy the Wasm Plugin using Istio API.
+
+<!-- TODO(incfly): provide the actual link once the blog is ready. -->
+For detailed instructions, checkout tetrate.io/blog.
+
+##  Build and publish Wasm extension on OCI registry
+
+
+Dependency:: TinyGo, and Docker CLI
+
+
+1. Compile the code to Wasm binary.
+
+```
+$ tinygo build -o main.wasm -scheduler=none -target=wasi main.go
+```
+
+2. Build docker image which is compliant with Wasm OCI image spec (https://github.com/solo-io/wasm/tree/master/spec)
+
+```
+# Note that replace ${WASM_EXTENSION_REGISTRY} with your OCI repo.
+# Here I push to GitHub Container Registry.
+$ export WASM_EXTENSION_REGISTRY=ghcr.io/mathetake/wasm-extension-demo
+$ docker build -t ${WASM_EXTENSION_REGISTRY}:v1 .
+```
+
+3. Publish the docker image to your OCI registry
+
+```
+# Make sure you already logged in to the registory.
+docker push ${WASM_EXTENSION_REGISTRY}:v1
+```
+

--- a/examples/istio_rate_limiting/README.md
+++ b/examples/istio_rate_limiting/README.md
@@ -1,7 +1,8 @@
 # Istio Wasm Demo for Rate Limiting
 
 Istio 1.12 release introduces new Wasm Extension API. This folder contains a sample application of
-implementing rate limiting in Golang, and deploy the Wasm Plugin using Istio API.
+implementing rate limiting in Golang, and deploy the Wasm Plugin using Istio API. The plugin will
+enforce rate limiting for 2 request per second. Extra request beyond the limit will be rejected.
 
 <!-- TODO(incfly): provide the actual link once the blog is ready. -->
 For detailed instructions, checkout tetrate.io/blog.

--- a/examples/istio_rate_limiting/main.go
+++ b/examples/istio_rate_limiting/main.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"time"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func main() {
+	proxywasm.SetVMContext(&vmContext{})
+}
+
+type vmContext struct {
+	// Embed the default VM context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultVMContext
+}
+
+// Override types.DefaultVMContext.
+func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &pluginContext{}
+}
+
+type pluginContext struct {
+	// Embed the default plugin context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultPluginContext
+	// the remaining token for rate limiting, refreshed periodically.
+	remainToken int
+	// // the preconfigured request per second for rate limiting.
+	// requestPerSecond int
+	// NOTE(jianfeih): any concerns about the threading and mutex usage for tinygo wasm?
+	// the last time the token is refilled with `requestPerSecond`.
+	lastRefillNanoSec int64
+}
+
+// Override types.DefaultPluginContext.
+func (p *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
+	return &httpHeaders{contextID: contextID, pluginContext: p}
+}
+
+type httpHeaders struct {
+	// Embed the default http context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultHttpContext
+	contextID     uint32
+	pluginContext *pluginContext
+}
+
+// Additional headers supposed to be injected to response headers.
+var additionalHeaders = map[string]string{
+	"who-am-i":    "wasm-extension",
+	"injected-by": "istio-api!",
+}
+
+func (ctx *httpHeaders) OnHttpResponseHeaders(numHeaders int, endOfStream bool) types.Action {
+	for key, value := range additionalHeaders {
+		proxywasm.AddHttpResponseHeader(key, value)
+	}
+	return types.ActionContinue
+}
+
+func (ctx *httpHeaders) OnHttpRequestHeaders(int, bool) types.Action {
+	current := time.Now().UnixNano()
+	// We use nanoseconds() rather than time.Second() because the proxy-wasm has the known limitation.
+	// TODO(incfly): change to time.Second() once https://github.com/proxy-wasm/proxy-wasm-cpp-host/issues/199
+	// is resolved and released.
+	if current > ctx.pluginContext.lastRefillNanoSec+1e9 {
+		ctx.pluginContext.remainToken = 2
+		ctx.pluginContext.lastRefillNanoSec = current
+	}
+	proxywasm.LogCriticalf("Current time %v, last refill time %v, the remain token %v",
+		current, ctx.pluginContext.lastRefillNanoSec, ctx.pluginContext.remainToken)
+	if ctx.pluginContext.remainToken == 0 {
+		if err := proxywasm.SendHttpResponse(403, [][2]string{
+			{"powered-by", "proxy-wasm-go-sdk!!"},
+		}, []byte("rate limited, wait and retry."), -1); err != nil {
+			proxywasm.LogErrorf("failed to send local response: %v", err)
+			proxywasm.ResumeHttpRequest()
+		}
+		return types.ActionPause
+	}
+	ctx.pluginContext.remainToken -= 1
+	return types.ActionContinue
+}

--- a/examples/istio_rate_limiting/wasm.yaml
+++ b/examples/istio_rate_limiting/wasm.yaml
@@ -1,0 +1,11 @@
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: header-injection
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  # TODO(incfly): replace this with an ECR once ready.
+  url: oci://ghcr.io/mathetake/wasm-extension-demo:v1

--- a/examples/istio_rate_limiting/wasm.yaml
+++ b/examples/istio_rate_limiting/wasm.yaml
@@ -7,5 +7,5 @@ spec:
   selector:
     matchLabels:
       app: httpbin
-  # TODO(incfly): replace this with an ECR once ready.
-  url: oci://ghcr.io/mathetake/wasm-extension-demo:v1
+  # TODO(incfly): replace this with an ECR image once ready.
+  url: oci://ghcr.io/incfly/proxy-wasm-go-sdk:v1


### PR DESCRIPTION
Adds a rate limiting example, to do rate limiting for 2 request per second.

Mostly changed from https://github.com/mathetake/istio-wasm-api-demo/blob/master/main.go
The actual read me will be referencing the upcoming blog on tetrate.io.

Signed-off-by: Jianfei Hu <hujianfei258@gmail.com>