### PR TITLE
WIP: Allow overriding WasmResult of mocked foreign functions

### DIFF
--- a/examples/foreign_call_on_tick/main_test.go
+++ b/examples/foreign_call_on_tick/main_test.go
@@ -27,7 +27,7 @@ func TestPluginContext_OnTick(t *testing.T) {
 	require.Equal(t, tickMilliseconds, host.GetTickPeriod())
 
 	// Register foreign function named "compress".
-	host.RegisterForeignFunction("compress", func(b []byte) []byte { return b })
+	host.RegisterForeignFunction("compress", func(b []byte) ([]byte, types.WasmResult) { return b, types.WasmResultOk })
 
 	for i := 1; i < 10; i++ {
 		host.Tick()

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -42,7 +42,7 @@ type HostEmulator interface {
 	GetTickPeriod() uint32
 	Tick()
 	GetQueueSize(queueID uint32) int
-	RegisterForeignFunction(name string, f func([]byte) []byte)
+	RegisterForeignFunction(name string, f func([]byte) ([]byte, types.WasmResult))
 
 	// network
 	InitializeConnection() (contextID uint32, action types.Action)

--- a/proxywasm/types/types.go
+++ b/proxywasm/types/types.go
@@ -80,3 +80,21 @@ var (
 	// ErrorUnimplemented indicates the API is not implemented in the host yet.
 	ErrorUnimplemented = errors.New("error status returned by host: unimplemented")
 )
+
+type WasmResult uint32
+
+const (
+	WasmResultOk                   WasmResult = 0
+	WasmResultNotFound             WasmResult = 1
+	WasmResultBadArgument          WasmResult = 2
+	WasmResultSerializationFailure WasmResult = 3
+	WasmResultParseFailure         WasmResult = 4
+	WasmResultBadExpression        WasmResult = 5
+	WasmResultInvalidMemoryAccess  WasmResult = 6
+	WasmResultEmpty                WasmResult = 7
+	WasmResultCasMismatch          WasmResult = 8
+	WasmResultResultMismatch       WasmResult = 9
+	WasmResultInternalFailure      WasmResult = 10
+	WasmResultBrokenConnection     WasmResult = 11
+	WasmResultUnimplemented        WasmResult = 12
+)


### PR DESCRIPTION
I'd like to be able to generate better coverage of my foreign functions, but right now, the code limits you to an implicit "Ok" result.  This prevents me testing some of the error paths behaviors in my WASM extensions.

This PR is an attempt to make that interface more generic. The problem I see is that I need a "WasmResult" type, but the only existing thing like that is internal.Status.....which is internal.

I've added an explicit WasmResult type, but with obvious downsides (internal.Status and types.WasmResult need to be in sync, otherwise things will get nasty).

I'm not 100% sure on the best path forward, but thought I'd open this PR to drive a discussion.  I welcome feedback on better/alternate approches!