### PR TITLE
ci: update Istio versions, drop 1.10, 1.9

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -82,11 +82,9 @@ jobs:
           "envoyproxy/envoy:v1.19-latest",
           "envoyproxy/envoy:v1.20-latest",
           "envoyproxy/envoy:v1.21-latest",
-          "istio/proxyv2:1.9.8",
-          "istio/proxyv2:1.10.4",
-          "istio/proxyv2:1.11.5",
-          "istio/proxyv2:1.12.1",
-          "istio/proxyv2:1.13.0",
+          "istio/proxyv2:1.11.7",
+          "istio/proxyv2:1.12.4",
+          "istio/proxyv2:1.13.1",
         ]
     name: E2E Test (${{ matrix.image }})
     needs: [build-examples]


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

1.10 and 1.9 have already reached EOL