### PR TITLE
Small fixes to JSON validation example

### DIFF
--- a/examples/json_validation/Dockerfile
+++ b/examples/json_validation/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
 
-COPY main.wasm ./
+COPY main.wasm ./plugin.wasm

--- a/examples/json_validation/README.md
+++ b/examples/json_validation/README.md
@@ -60,8 +60,8 @@ kind create cluster
 
 istioctl install --set profile=demo -y
 kubectl label namespace default istio-injection=enabled
-kubectl apply -f https://github.com/istio/istio/blob/48cdd8/samples/httpbin/httpbin.yaml
-kubectl apply -f https://github.com/istio/istio/blob/48cdd8/samples/httpbin/httpbin-gateway.yaml
+kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.12/samples/httpbin/httpbin.yaml
+kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.12/samples/httpbin/httpbin-gateway.yaml
 ```
 
 For Istio 1.12 and later the easiest way is to use a WasmPlugin resource. For older Istio


### PR DESCRIPTION
- Have Dockerfile copy plugin into filename plugin.wasm, otherwise it
doesn't work.
- Use raw.githubusercontent.com links instead of github.com ones that
return html and can't be applied directly.