### PR TITLE
ci: run e2e on Envoy 1.22

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -78,10 +78,10 @@ jobs:
       matrix:
         image: [ 
           "envoyproxy/envoy-dev:latest",
-          "envoyproxy/envoy:v1.18-latest",
           "envoyproxy/envoy:v1.19-latest",
           "envoyproxy/envoy:v1.20-latest",
           "envoyproxy/envoy:v1.21-latest",
+          "envoyproxy/envoy:v1.22-latest",
           "istio/proxyv2:1.11.7",
           "istio/proxyv2:1.12.4",
           "istio/proxyv2:1.13.1",

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -52,7 +52,7 @@ func checkMessage(str string, exps, nexps []string) bool {
 
 func startEnvoy(t *testing.T, adminPort int) (stdErr *bytes.Buffer, kill func()) {
 	name := strings.TrimPrefix(t.Name(), "Test_")
-	cmd := exec.Command("envoy",
+	cmd := exec.Command("./envoy",
 		"--base-id", strconv.Itoa(adminPort),
 		"--concurrency", "1", "--component-log-level", "wasm:trace",
 		"-c", fmt.Sprintf("./examples/%s/envoy.yaml", name))

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -52,7 +52,7 @@ func checkMessage(str string, exps, nexps []string) bool {
 
 func startEnvoy(t *testing.T, adminPort int) (stdErr *bytes.Buffer, kill func()) {
 	name := strings.TrimPrefix(t.Name(), "Test_")
-	cmd := exec.Command("./envoy",
+	cmd := exec.Command("envoy",
 		"--base-id", strconv.Itoa(adminPort),
 		"--concurrency", "1", "--component-log-level", "wasm:trace",
 		"-c", fmt.Sprintf("./examples/%s/envoy.yaml", name))

--- a/examples/dispatch_call_on_tick/envoy.yaml
+++ b/examples/dispatch_call_on_tick/envoy.yaml
@@ -53,6 +53,8 @@ static_resources:
                               local:
                                 filename: "./examples/dispatch_call_on_tick/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
     - name: staticreply
       address:
@@ -86,7 +88,8 @@ static_resources:
 
                 http_filters:
                   - name: envoy.filters.http.router
-                    typed_config: {}
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
     - name: web_service

--- a/examples/foreign_call_on_tick/envoy.yaml
+++ b/examples/foreign_call_on_tick/envoy.yaml
@@ -38,6 +38,9 @@ static_resources:
                               local:
                                 filename: "./examples/foreign_call_on_tick/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
 
 admin:
   access_log_path: "/dev/null"

--- a/examples/helloworld/envoy.yaml
+++ b/examples/helloworld/envoy.yaml
@@ -38,6 +38,8 @@ static_resources:
                               local:
                                 filename: "./examples/helloworld/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
 admin:
   access_log_path: "/dev/null"

--- a/examples/http_auth_random/envoy.yaml
+++ b/examples/http_auth_random/envoy.yaml
@@ -36,6 +36,8 @@ static_resources:
                               local:
                                 filename: "./examples/http_auth_random/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
     - name: httpbin

--- a/examples/http_body/envoy.yaml
+++ b/examples/http_body/envoy.yaml
@@ -39,6 +39,8 @@ static_resources:
                               local:
                                 filename: "./examples/http_body/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
     - name: echo
       address:
@@ -79,6 +81,9 @@ static_resources:
                               local:
                                 filename: "./examples/http_body/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
 
   clusters:
     - name: echo

--- a/examples/http_headers/envoy.yaml
+++ b/examples/http_headers/envoy.yaml
@@ -36,6 +36,8 @@ static_resources:
                               local:
                                 filename: "./examples/http_headers/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
     - name: staticreply
       address:
@@ -64,7 +66,8 @@ static_resources:
                               inline_string: "example body\n"
                 http_filters:
                   - name: envoy.filters.http.router
-                    typed_config: {}
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
     - name: web_service

--- a/examples/http_routing/envoy.yaml
+++ b/examples/http_routing/envoy.yaml
@@ -44,6 +44,8 @@ static_resources:
                               local:
                                 filename: "./examples/http_routing/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
     - name: staticreply
       address:
@@ -72,6 +74,8 @@ static_resources:
                               inline_string: "hello from primary!\n"
                 http_filters:
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
     - name: staticreply_canary
       address:
@@ -100,6 +104,8 @@ static_resources:
                               inline_string: "hello from canary!\n"
                 http_filters:
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
     - name: primary

--- a/examples/json_validation/envoy.yaml
+++ b/examples/json_validation/envoy.yaml
@@ -45,6 +45,8 @@ static_resources:
                               local:
                                 filename: "./examples/json_validation/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
     - name: staticreply
       address:
@@ -73,7 +75,8 @@ static_resources:
                               inline_string: "hello from the server\n"
                 http_filters:
                   - name: envoy.filters.http.router
-                    typed_config: {}
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
     - name: web_service

--- a/examples/metrics/envoy.yaml
+++ b/examples/metrics/envoy.yaml
@@ -48,6 +48,8 @@ static_resources:
                               local:
                                 filename: "./examples/metrics/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
 admin:
   access_log_path: "/dev/null"

--- a/examples/network/envoy.yaml
+++ b/examples/network/envoy.yaml
@@ -50,6 +50,8 @@ static_resources:
                               inline_string: "example body\n"
                 http_filters:
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
     - name: web_service

--- a/examples/postpone_requests/envoy.yaml
+++ b/examples/postpone_requests/envoy.yaml
@@ -38,6 +38,8 @@ static_resources:
                               local:
                                 filename: "./examples/postpone_requests/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
 admin:
   access_log_path: "/dev/null"

--- a/examples/shared_data/envoy.yaml
+++ b/examples/shared_data/envoy.yaml
@@ -38,6 +38,8 @@ static_resources:
                               local:
                                 filename: "./examples/shared_data/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
 admin:
   access_log_path: "/dev/null"

--- a/examples/shared_queue/envoy.yaml
+++ b/examples/shared_queue/envoy.yaml
@@ -94,6 +94,9 @@ static_resources:
                             local:
                               filename: "./examples/shared_queue/sender/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
     - name: tcp
       address:
         socket_address:

--- a/examples/vm_plugin_configuration/envoy.yaml
+++ b/examples/vm_plugin_configuration/envoy.yaml
@@ -48,6 +48,8 @@ static_resources:
                             local:
                               filename: "./examples/vm_plugin_configuration/main.wasm"
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
 admin:
   access_log_path: "/dev/null"


### PR DESCRIPTION
Also, drops the test target of 1.18 as it's reached EOL

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>