### PR TITLE
Add the ability to get the current response headers in proxytest

### DIFF
--- a/proxywasm/proxytest/http.go
+++ b/proxywasm/proxytest/http.go
@@ -446,6 +446,15 @@ func (h *httpHostEmulator) GetCurrentRequestHeaders(contextID uint32) [][2]strin
 }
 
 // impl HostEmulator
+func (h *httpHostEmulator) GetCurrentResponseHeaders(contextID uint32) [][2]string {
+	stream, ok := h.httpStreams[contextID]
+	if !ok {
+		log.Fatalf("invalid context id: %d", contextID)
+	}
+	return stream.responseHeaders
+}
+
+// impl HostEmulator
 func (h *httpHostEmulator) GetCurrentRequestBody(contextID uint32) []byte {
 	stream, ok := h.httpStreams[contextID]
 	if !ok {

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -63,6 +63,7 @@ type HostEmulator interface {
 	CompleteHttpContext(contextID uint32)
 	GetCurrentHttpStreamAction(contextID uint32) types.Action
 	GetCurrentRequestHeaders(contextID uint32) [][2]string
+	GetCurrentResponseHeaders(contextID uint32) [][2]string
 	GetCurrentRequestBody(contextID uint32) []byte
 	GetSentLocalResponse(contextID uint32) *LocalHttpResponse
 }


### PR DESCRIPTION
Hi, this is my first stab at adding the ability to get the current response headers when running tests. At first it seems rather straightforward to add this, but I have been wrong before ;-)