### PR TITLE
feat(log): filter out logs based on log level threshold

### DIFF
--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -18,8 +18,10 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync/atomic"
 
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/internal"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/log"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
 )
 
@@ -589,70 +591,93 @@ func CallForeignFunction(funcName string, param []byte) (ret []byte, err error) 
 	}
 }
 
-// LogTracef emits a message as a log with Trace log level.
+var (
+	logLevel = new(int32)
+)
+
+// LogLevel returns the current log level.
+func LogLevel() log.Level {
+	return log.Level(atomic.LoadInt32(logLevel))
+}
+
+// SetLogLevel sets the log level to the provided level.
+func SetLogLevel(lvl log.Level) {
+	atomic.StoreInt32(logLevel, int32(lvl))
+}
+
+// Log emits a message as a log with the specified log level.
+func Log(lvl log.Level, msg string) {
+	if lvl >= LogLevel() && lvl < log.LevelDisabled {
+		internal.ProxyLog(lvl, internal.StringBytePtr(msg), len(msg))
+	}
+}
+
+// Logf formats according to a format specifier and emits as a log with the specified log level.
+func Logf(lvl log.Level, format string, args ...interface{}) {
+	if lvl >= LogLevel() && lvl < log.LevelDisabled {
+		msg := fmt.Sprintf(format, args...)
+		internal.ProxyLog(lvl, internal.StringBytePtr(msg), len(msg))
+	}
+}
+
+// LogTrace emits a message as a log with Trace log level.
 func LogTrace(msg string) {
-	internal.ProxyLog(internal.LogLevelTrace, internal.StringBytePtr(msg), len(msg))
+	Log(log.LevelTrace, msg)
 }
 
 // LogTracef formats according to a format specifier and emits as a log with Trace log level.
 func LogTracef(format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
-	internal.ProxyLog(internal.LogLevelTrace, internal.StringBytePtr(msg), len(msg))
+	Logf(log.LevelTrace, format, args...)
 }
 
-// LogTracef emits a message as a log with Debug log level.
+// LogDebug emits a message as a log with Debug log level.
 func LogDebug(msg string) {
-	internal.ProxyLog(internal.LogLevelDebug, internal.StringBytePtr(msg), len(msg))
+	Log(log.LevelDebug, msg)
 }
 
 // LogDebugf formats according to a format specifier and emits as a log with Debug log level.
 func LogDebugf(format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
-	internal.ProxyLog(internal.LogLevelDebug, internal.StringBytePtr(msg), len(msg))
+	Logf(log.LevelDebug, format, args...)
 }
 
-// LogTracef emits a message as a log with Info log level.
+// LogInfo emits a message as a log with Info log level.
 func LogInfo(msg string) {
-	internal.ProxyLog(internal.LogLevelInfo, internal.StringBytePtr(msg), len(msg))
+	Log(log.LevelInfo, msg)
 }
 
 // LogInfof formats according to a format specifier and emits as a log with Info log level.
 func LogInfof(format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
-	internal.ProxyLog(internal.LogLevelInfo, internal.StringBytePtr(msg), len(msg))
+	Logf(log.LevelInfo, format, args...)
 }
 
-// LogTracef emits a message as a log with Warn log level.
+// LogWarn emits a message as a log with Warn log level.
 func LogWarn(msg string) {
-	internal.ProxyLog(internal.LogLevelWarn, internal.StringBytePtr(msg), len(msg))
+	Log(log.LevelWarn, msg)
 }
 
 // LogWarnf formats according to a format specifier and emits as a log with Warn log level.
 func LogWarnf(format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
-	internal.ProxyLog(internal.LogLevelWarn, internal.StringBytePtr(msg), len(msg))
+	Logf(log.LevelWarn, format, args...)
 }
 
-// LogTracef emits a message as a log with Error log level.
+// LogError emits a message as a log with Error log level.
 func LogError(msg string) {
-	internal.ProxyLog(internal.LogLevelError, internal.StringBytePtr(msg), len(msg))
+	Log(log.LevelError, msg)
 }
 
 // LogErrorf formats according to a format specifier and emits as a log with Error log level.
 func LogErrorf(format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
-	internal.ProxyLog(internal.LogLevelError, internal.StringBytePtr(msg), len(msg))
+	Logf(log.LevelError, format, args...)
 }
 
-// LogTracef emits a message as a log with Critical log level.
+// LogCritical emits a message as a log with Critical log level.
 func LogCritical(msg string) {
-	internal.ProxyLog(internal.LogLevelCritical, internal.StringBytePtr(msg), len(msg))
+	Log(log.LevelCritical, msg)
 }
 
 // LogCriticalf formats according to a format specifier and emits as a log with Critical log level.
 func LogCriticalf(format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
-	internal.ProxyLog(internal.LogLevelCritical, internal.StringBytePtr(msg), len(msg))
+	Logf(log.LevelCritical, format, args...)
 }
 
 type (

--- a/proxywasm/internal/abi_enums.go
+++ b/proxywasm/internal/abi_enums.go
@@ -21,37 +21,6 @@ const (
 	BufferTypeCallData             BufferType = 8
 )
 
-type LogLevel uint32
-
-const (
-	LogLevelTrace    LogLevel = 0
-	LogLevelDebug    LogLevel = 1
-	LogLevelInfo     LogLevel = 2
-	LogLevelWarn     LogLevel = 3
-	LogLevelError    LogLevel = 4
-	LogLevelCritical LogLevel = 5
-	LogLevelMax      LogLevel = 6
-)
-
-func (l LogLevel) String() string {
-	switch l {
-	case LogLevelTrace:
-		return "trace"
-	case LogLevelDebug:
-		return "debug"
-	case LogLevelInfo:
-		return "info"
-	case LogLevelWarn:
-		return "warn"
-	case LogLevelError:
-		return "error"
-	case LogLevelCritical:
-		return "critical"
-	default:
-		panic("invalid log level")
-	}
-}
-
 type MapType uint32
 
 const (

--- a/proxywasm/internal/abi_hostcalls.go
+++ b/proxywasm/internal/abi_hostcalls.go
@@ -16,8 +16,10 @@
 
 package internal
 
+import "github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/log"
+
 //export proxy_log
-func ProxyLog(logLevel LogLevel, messageData *byte, messageSize int) Status
+func ProxyLog(logLevel log.Level, messageData *byte, messageSize int) Status
 
 //export proxy_send_local_response
 func ProxySendLocalResponse(statusCode uint32, statusCodeDetailData *byte, statusCodeDetailsSize int,

--- a/proxywasm/internal/abi_hostcalls_mock.go
+++ b/proxywasm/internal/abi_hostcalls_mock.go
@@ -21,6 +21,8 @@ package internal
 
 import (
 	"sync"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/log"
 )
 
 var (
@@ -37,7 +39,7 @@ func RegisterMockWasmHost(host ProxyWasmHost) (release func()) {
 }
 
 type ProxyWasmHost interface {
-	ProxyLog(logLevel LogLevel, messageData *byte, messageSize int) Status
+	ProxyLog(logLevel log.Level, messageData *byte, messageSize int) Status
 	ProxySetProperty(pathData *byte, pathSize int, valueData *byte, valueSize int) Status
 	ProxyGetProperty(pathData *byte, pathSize int, returnValueData **byte, returnValueSize *int) Status
 	ProxySendLocalResponse(statusCode uint32, statusCodeDetailData *byte, statusCodeDetailsSize int, bodyData *byte, bodySize int, headersData *byte, headersSize int, grpcStatus int32) Status
@@ -72,7 +74,7 @@ type DefaultProxyWAMSHost struct{}
 
 var _ ProxyWasmHost = DefaultProxyWAMSHost{}
 
-func (d DefaultProxyWAMSHost) ProxyLog(logLevel LogLevel, messageData *byte, messageSize int) Status {
+func (d DefaultProxyWAMSHost) ProxyLog(logLevel log.Level, messageData *byte, messageSize int) Status {
 	return 0
 }
 func (d DefaultProxyWAMSHost) ProxySetProperty(pathData *byte, pathSize int, valueData *byte, valueSize int) Status {
@@ -148,7 +150,7 @@ func (d DefaultProxyWAMSHost) ProxyGetMetric(metricID uint32, returnMetricValue 
 	return 0
 }
 
-func ProxyLog(logLevel LogLevel, messageData *byte, messageSize int) Status {
+func ProxyLog(logLevel log.Level, messageData *byte, messageSize int) Status {
 	return currentHost.ProxyLog(logLevel, messageData, messageSize)
 }
 

--- a/proxywasm/log/log.go
+++ b/proxywasm/log/log.go
@@ -1,0 +1,68 @@
+package log
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Enumeration of log levels.
+//
+// LevelDisabled is a special case to disable logging. It must remain last.
+const (
+	LevelTrace Level = iota
+	LevelDebug
+	LevelInfo
+	LevelWarn
+	LevelError
+	LevelCritical
+	LevelDisabled
+)
+
+// Level defines log levels.
+type Level uint32
+
+// ParseLevel converts a level string into a Level value.
+// It returns an error if the level string does not match a known value.
+func ParseLevel(level string) (Level, error) {
+	switch strings.ToLower(level) {
+	case "trace":
+		return LevelTrace, nil
+	case "debug":
+		return LevelDebug, nil
+	case "info":
+		return LevelInfo, nil
+	case "warn":
+		return LevelWarn, nil
+	case "error":
+		return LevelError, nil
+	case "critical":
+		return LevelCritical, nil
+	case "disabled":
+		return LevelDisabled, nil
+	default:
+		return 0, fmt.Errorf("unknown level string: %q", level)
+	}
+}
+
+// String returns a string representation of the log level.
+// It makes Level implement the fmt.Stringer interface.
+func (l Level) String() string {
+	switch l {
+	case LevelTrace:
+		return "trace"
+	case LevelDebug:
+		return "debug"
+	case LevelInfo:
+		return "info"
+	case LevelWarn:
+		return "warn"
+	case LevelError:
+		return "error"
+	case LevelCritical:
+		return "critical"
+	case LevelDisabled:
+		return "disabled"
+	default:
+		panic("invalid log level")
+	}
+}

--- a/proxywasm/log/log_test.go
+++ b/proxywasm/log/log_test.go
@@ -1,0 +1,59 @@
+package log_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/log"
+)
+
+func TestParseLevel(t *testing.T) {
+	testCases := []struct {
+		level         string
+		expectedLevel Level
+		expectedErr   error
+	}{
+		{level: "trace", expectedLevel: LevelTrace},
+		{level: "debug", expectedLevel: LevelDebug},
+		{level: "info", expectedLevel: LevelInfo},
+		{level: "warn", expectedLevel: LevelWarn},
+		{level: "error", expectedLevel: LevelError},
+		{level: "critical", expectedLevel: LevelCritical},
+		{level: "disabled", expectedLevel: LevelDisabled},
+		{level: "invalid", expectedErr: errors.New(`unknown level string: "invalid"`)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.level, func(t *testing.T) {
+			lvl, err := ParseLevel(tc.level)
+
+			assert.Equal(t, tc.expectedLevel, lvl)
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}
+
+func TestLevel_String(t *testing.T) {
+	testCases := []struct {
+		level        Level
+		exptectedStr string
+	}{
+		{level: LevelTrace, exptectedStr: "trace"},
+		{level: LevelDebug, exptectedStr: "debug"},
+		{level: LevelInfo, exptectedStr: "info"},
+		{level: LevelWarn, exptectedStr: "warn"},
+		{level: LevelError, exptectedStr: "error"},
+		{level: LevelCritical, exptectedStr: "critical"},
+		{level: LevelDisabled, exptectedStr: "disabled"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.exptectedStr, func(t *testing.T) {
+			str := tc.level.String()
+
+			assert.Equal(t, tc.exptectedStr, str)
+		})
+	}
+}


### PR DESCRIPTION
The change exposes available log levels to end-user which become
now part of the proxywasm interface.
SetLogLevel and LogLevel functions have been added to proxywasm package
to respectively set and get the log level threshold.
This threshold is used to filter out log entries.