### PR TITLE
Add a wrapper for running compiled wasm plugins with proxytest.

### DIFF
--- a/examples/dispatch_call_on_tick/go.mod
+++ b/examples/dispatch_call_on_tick/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/dispatch_call_on_tick/go.sum
+++ b/examples/dispatch_call_on_tick/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/foreign_call_on_tick/go.mod
+++ b/examples/foreign_call_on_tick/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/foreign_call_on_tick/go.sum
+++ b/examples/foreign_call_on_tick/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/helloworld/go.mod
+++ b/examples/helloworld/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/helloworld/go.sum
+++ b/examples/helloworld/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/http_auth_random/go.mod
+++ b/examples/http_auth_random/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/http_auth_random/go.sum
+++ b/examples/http_auth_random/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/http_body/go.mod
+++ b/examples/http_body/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/http_body/go.sum
+++ b/examples/http_body/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/http_headers/go.mod
+++ b/examples/http_headers/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/http_headers/go.sum
+++ b/examples/http_headers/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/http_routing/go.mod
+++ b/examples/http_routing/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/http_routing/go.sum
+++ b/examples/http_routing/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/json_validation/go.mod
+++ b/examples/json_validation/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/examples/json_validation/go.sum
+++ b/examples/json_validation/go.sum
@@ -6,6 +6,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 github.com/tidwall/gjson v1.14.1 h1:iymTbGkQBhveq21bEvAQ81I0LEBork8BFe1CUZXdyuo=
 github.com/tidwall/gjson v1.14.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -15,6 +17,5 @@ github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhso
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/metrics/go.mod
+++ b/examples/metrics/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/metrics/go.sum
+++ b/examples/metrics/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/multiple_dispatches/go.mod
+++ b/examples/multiple_dispatches/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/multiple_dispatches/go.sum
+++ b/examples/multiple_dispatches/go.sum
@@ -6,6 +6,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/network/go.mod
+++ b/examples/network/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/network/go.sum
+++ b/examples/network/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/postpone_requests/go.mod
+++ b/examples/postpone_requests/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/postpone_requests/go.sum
+++ b/examples/postpone_requests/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/shared_data/go.mod
+++ b/examples/shared_data/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/shared_data/go.sum
+++ b/examples/shared_data/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/shared_queue/go.mod
+++ b/examples/shared_queue/go.mod
@@ -5,5 +5,3 @@ go 1.17
 replace github.com/tetratelabs/proxy-wasm-go-sdk => ../..
 
 require github.com/tetratelabs/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
-
-require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/examples/shared_queue/go.sum
+++ b/examples/shared_queue/go.sum
@@ -6,8 +6,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/vm_plugin_configuration/go.mod
+++ b/examples/vm_plugin_configuration/go.mod
@@ -12,5 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/vm_plugin_configuration/go.sum
+++ b/examples/vm_plugin_configuration/go.sum
@@ -6,9 +6,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require github.com/stretchr/testify v1.7.1
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,13 @@ module github.com/tetratelabs/proxy-wasm-go-sdk
 
 go 1.17
 
-require github.com/stretchr/testify v1.7.1
+require (
+	github.com/stretchr/testify v1.7.1
+	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f h1:+InPNMTyR4bufxW+MzqigSOXpe9Ph++NOIz/N9wtEYs=
+github.com/tetratelabs/wazero v0.0.0-20220819021810-7f8e629c653f/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/proxywasm/internal/hostcall_utils_tinygo.go
+++ b/proxywasm/internal/hostcall_utils_tinygo.go
@@ -26,6 +26,9 @@ import (
 )
 
 func RawBytePtrToString(raw *byte, size int) string {
+	if size == 0 {
+		return ""
+	}
 	return *(*string)(unsafe.Pointer(&reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(raw)),
 		Len:  uintptr(size),
@@ -34,6 +37,9 @@ func RawBytePtrToString(raw *byte, size int) string {
 }
 
 func RawBytePtrToByteSlice(raw *byte, size int) []byte {
+	if size == 0 {
+		return nil
+	}
 	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(raw)),
 		Len:  uintptr(size),

--- a/proxywasm/internal/hostcall_utils_tinygo.go
+++ b/proxywasm/internal/hostcall_utils_tinygo.go
@@ -26,9 +26,6 @@ import (
 )
 
 func RawBytePtrToString(raw *byte, size int) string {
-	if size == 0 {
-		return ""
-	}
 	return *(*string)(unsafe.Pointer(&reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(raw)),
 		Len:  uintptr(size),
@@ -37,9 +34,6 @@ func RawBytePtrToString(raw *byte, size int) string {
 }
 
 func RawBytePtrToByteSlice(raw *byte, size int) []byte {
-	if size == 0 {
-		return nil
-	}
 	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(raw)),
 		Len:  uintptr(size),

--- a/proxywasm/proxytest/wasmwrapper.go
+++ b/proxywasm/proxytest/wasmwrapper.go
@@ -65,7 +65,7 @@ type vmContext struct {
 // with Go and with wasm. Tests will run much faster under Go for quicker development cycles, and the wasm runner can
 // confirm the behavior matches when actually compiled.
 //
-// For example, this snippet allows determining the `VMContext` based on a test case flag.
+// For example, this snippet allows determining the types.VMContext based on a test case flag.
 //
 //	var vm types.VMContext
 //	switch runner {

--- a/proxywasm/proxytest/wasmwrapper.go
+++ b/proxywasm/proxytest/wasmwrapper.go
@@ -61,7 +61,7 @@ type vmContext struct {
 // proxytest can be run with a compiled wasm binary by passing this to proxytest.WithVMContext.
 //
 // Running proxytest with the compiled wasm binary helps to ensure that the plugin will run when actually compiled with
-// TinyGo, however Stack traces and other debug features will be much worse. It is recommended to run unit tests both
+// TinyGo, however stack traces and other debug features will be much worse. It is recommended to run unit tests both
 // with Go and with wasm. Tests will run much faster under Go for quicker development cycles, and the wasm runner can
 // confirm the behavior matches when actually compiled.
 //

--- a/proxywasm/proxytest/wasmwrapper.go
+++ b/proxywasm/proxytest/wasmwrapper.go
@@ -1,0 +1,423 @@
+// Copyright 2020-2022 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxytest
+
+import (
+	"context"
+	"reflect"
+	"unsafe"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/wasi_snapshot_preview1"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/internal"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+type guestABI struct {
+	proxyOnVMStart          api.Function
+	proxyOnContextCreate    api.Function
+	proxyOnConfigure        api.Function
+	proxyOnDone             api.Function
+	proxyOnQueueReady       api.Function
+	proxyOnTick             api.Function
+	proxyOnRequestHeaders   api.Function
+	proxyOnRequestBody      api.Function
+	proxyOnRequestTrailers  api.Function
+	proxyOnResponseHeaders  api.Function
+	proxyOnResponseBody     api.Function
+	proxyOnResponseTrailers api.Function
+	proxyOnLog              api.Function
+}
+
+type vmContext struct {
+	runtime wazero.Runtime
+	abi     guestABI
+}
+
+// NewWasmVMContext returns a types.VMContext that delegates plugin invocations to the provided compiled wasm binary.
+// proxytest can be run with a compiled wasm binary by passing this to proxytest.WithVMContext.
+// Note: Currently only HTTP plugins are supported.
+func NewWasmVMContext(wasm []byte) (types.VMContext, error) {
+	ctx := context.Background()
+	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithWasmCore2())
+
+	_, err := wasi_snapshot_preview1.Instantiate(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	err = exportHostABI(r)
+	if err != nil {
+		return nil, err
+	}
+
+	mod, err := r.InstantiateModuleFromBinary(ctx, wasm)
+	if err != nil {
+		return nil, err
+	}
+
+	abi := guestABI{
+		proxyOnVMStart:          mod.ExportedFunction("proxy_on_vm_start"),
+		proxyOnContextCreate:    mod.ExportedFunction("proxy_on_context_create"),
+		proxyOnConfigure:        mod.ExportedFunction("proxy_on_configure"),
+		proxyOnDone:             mod.ExportedFunction("proxy_on_done"),
+		proxyOnQueueReady:       mod.ExportedFunction("proxy_on_queue_ready"),
+		proxyOnTick:             mod.ExportedFunction("proxy_on_tick"),
+		proxyOnRequestHeaders:   mod.ExportedFunction("proxy_on_request_headers"),
+		proxyOnRequestBody:      mod.ExportedFunction("proxy_on_request_body"),
+		proxyOnRequestTrailers:  mod.ExportedFunction("proxy_on_request_trailers"),
+		proxyOnResponseHeaders:  mod.ExportedFunction("proxy_on_response_headers"),
+		proxyOnResponseBody:     mod.ExportedFunction("proxy_on_response_body"),
+		proxyOnResponseTrailers: mod.ExportedFunction("proxy_on_response_trailers"),
+		proxyOnLog:              mod.ExportedFunction("proxy_on_log"),
+	}
+
+	return &vmContext{
+		runtime: r,
+		abi:     abi,
+	}, nil
+}
+
+func (v *vmContext) OnVMStart(vmConfigurationSize int) types.OnVMStartStatus {
+	res, err := v.abi.proxyOnVMStart.Call(nil, uint64(vmConfigurationSize))
+	handleErr(err)
+	return res[0] == 1
+}
+
+func (v *vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	_, err := v.abi.proxyOnContextCreate.Call(nil, uint64(contextID), 0)
+	handleErr(err)
+	return &pluginContext{
+		id:  uint64(contextID),
+		abi: v.abi,
+		ctx: context.Background(),
+	}
+}
+
+type pluginContext struct {
+	id  uint64
+	abi guestABI
+	ctx context.Context
+}
+
+func (p *pluginContext) OnPluginStart(pluginConfigurationSize int) types.OnPluginStartStatus {
+	res, err := p.abi.proxyOnConfigure.Call(p.ctx, p.id, uint64(pluginConfigurationSize))
+	handleErr(err)
+	return res[0] == 1
+}
+
+func (p *pluginContext) OnPluginDone() bool {
+	res, err := p.abi.proxyOnDone.Call(p.ctx, p.id)
+	handleErr(err)
+	return res[0] == 1
+}
+
+func (p *pluginContext) OnQueueReady(queueID uint32) {
+	_, err := p.abi.proxyOnQueueReady.Call(p.ctx, p.id, uint64(queueID))
+	handleErr(err)
+}
+
+func (p *pluginContext) OnTick() {
+	_, err := p.abi.proxyOnTick.Call(p.ctx, p.id)
+	handleErr(err)
+}
+
+func (p *pluginContext) NewTcpContext(uint32) types.TcpContext {
+	return nil
+}
+
+func (p *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
+	_, err := p.abi.proxyOnContextCreate.Call(p.ctx, uint64(contextID), p.id)
+	handleErr(err)
+	return &httpContext{
+		id:  uint64(contextID),
+		abi: p.abi,
+		ctx: p.ctx,
+	}
+}
+
+type httpContext struct {
+	id  uint64
+	abi guestABI
+	ctx context.Context
+}
+
+func (h *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	res, err := h.abi.proxyOnRequestHeaders.Call(h.ctx, h.id, uint64(numHeaders), wasmBool(endOfStream))
+	handleErr(err)
+	return types.Action(res[0])
+}
+
+func (h *httpContext) OnHttpRequestBody(bodySize int, endOfStream bool) types.Action {
+	res, err := h.abi.proxyOnRequestBody.Call(h.ctx, h.id, uint64(bodySize), wasmBool(endOfStream))
+	handleErr(err)
+	return types.Action(res[0])
+}
+
+func (h *httpContext) OnHttpRequestTrailers(numTrailers int) types.Action {
+	res, err := h.abi.proxyOnRequestTrailers.Call(h.ctx, h.id, uint64(numTrailers))
+	handleErr(err)
+	return types.Action(res[0])
+}
+
+func (h *httpContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) types.Action {
+	res, err := h.abi.proxyOnResponseHeaders.Call(h.ctx, h.id, uint64(numHeaders), wasmBool(endOfStream))
+	handleErr(err)
+	return types.Action(res[0])
+}
+
+func (h *httpContext) OnHttpResponseBody(bodySize int, endOfStream bool) types.Action {
+	res, err := h.abi.proxyOnResponseBody.Call(h.ctx, h.id, uint64(bodySize), wasmBool(endOfStream))
+	handleErr(err)
+	return types.Action(res[0])
+}
+
+func (h *httpContext) OnHttpResponseTrailers(numTrailers int) types.Action {
+	res, err := h.abi.proxyOnResponseTrailers.Call(h.ctx, h.id, uint64(numTrailers))
+	handleErr(err)
+	return types.Action(res[0])
+}
+
+func (h *httpContext) OnHttpStreamDone() {
+	_, err := h.abi.proxyOnLog.Call(h.ctx, h.id)
+	handleErr(err)
+}
+
+func handleErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func handleMemoryStatus(ok bool) {
+	if !ok {
+		panic("could not access memory")
+	}
+}
+
+func wasmBytePtr(ctx context.Context, mod api.Module, off uint32, size uint32) *byte {
+	if size == 0 {
+		return nil
+
+	}
+	buf, ok := mod.Memory().Read(ctx, off, size)
+	handleMemoryStatus(ok)
+	return &buf[0]
+}
+
+func copyBytesToWasm(ctx context.Context, mod api.Module, hostPtr *byte, size int, wasmPtrPtr uint32, wasmSizePtr uint32) {
+	var hostSlice []byte
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&hostSlice))
+	hdr.Data = uintptr(unsafe.Pointer(hostPtr))
+	hdr.Cap = size
+	hdr.Len = size
+
+	// proxy-wasm only defines alloc without free so this leaks memory within the wasm module.
+	// A future cleanup could allow specifying buffers when initializing the host module, which
+	// would be from the sandbox memory when using the wasm wrapper.
+	alloc := mod.ExportedFunction("proxy_on_memory_allocate")
+	res, err := alloc.Call(ctx, uint64(size))
+	handleErr(err)
+	buf, ok := mod.Memory().Read(ctx, uint32(res[0]), uint32(size))
+	handleMemoryStatus(ok)
+
+	copy(buf, hostSlice)
+	ok = mod.Memory().WriteUint32Le(ctx, wasmPtrPtr, uint32(res[0]))
+	handleMemoryStatus(ok)
+
+	ok = mod.Memory().WriteUint32Le(ctx, wasmSizePtr, uint32(size))
+	handleMemoryStatus(ok)
+}
+
+func wasmBool(b bool) uint64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func exportHostABI(r wazero.Runtime) error {
+	_, err := r.NewModuleBuilder("env").
+		ExportFunction("proxy_log", func(ctx context.Context, mod api.Module, logLevel uint32, messageData uint32, messageSize uint32) uint32 {
+			messageDataPtr := wasmBytePtr(ctx, mod, messageData, messageSize)
+			return uint32(internal.ProxyLog(internal.LogLevel(logLevel), messageDataPtr, int(messageSize)))
+		}).
+		ExportFunction("proxy_set_property", func(ctx context.Context, mod api.Module, pathData uint32, pathSize uint32, valueData uint32, valueSize uint32) uint32 {
+			pathDataPtr := wasmBytePtr(ctx, mod, pathData, pathSize)
+			valueDataPtr := wasmBytePtr(ctx, mod, valueData, valueSize)
+			return uint32(internal.ProxySetProperty(pathDataPtr, int(pathSize), valueDataPtr, int(valueSize)))
+		}).
+		ExportFunction("proxy_get_property", func(ctx context.Context, mod api.Module, pathData uint32, pathSize uint32,
+			returnValueData uint32, returnValueSize uint32) uint32 {
+			pathDataPtr := wasmBytePtr(ctx, mod, pathData, pathSize)
+			var returnValueHostPtr *byte
+			var returnValueSizePtr int
+			ret := uint32(internal.ProxyGetProperty(pathDataPtr, int(pathSize), &returnValueHostPtr, &returnValueSizePtr))
+			copyBytesToWasm(ctx, mod, returnValueHostPtr, returnValueSizePtr, returnValueData, returnValueSize)
+			return ret
+		}).
+		ExportFunction("proxy_send_local_response", func(ctx context.Context, mod api.Module,
+			statusCode uint32, statusCodeDetailData uint32, statusCodeDetailsSize uint32,
+			bodyData uint32, bodySize uint32, headersData uint32, headersSize uint32, grpcStatus int32) uint32 {
+			statusCodeDetailDataPtr := wasmBytePtr(ctx, mod, statusCodeDetailData, statusCodeDetailsSize)
+			bodyDataPtr := wasmBytePtr(ctx, mod, bodyData, bodySize)
+			headersDataPtr := wasmBytePtr(ctx, mod, headersData, headersSize)
+			return uint32(internal.ProxySendLocalResponse(statusCode, statusCodeDetailDataPtr, int(statusCodeDetailsSize),
+				bodyDataPtr, int(bodySize), headersDataPtr, int(headersSize), grpcStatus))
+		}).
+		ExportFunction("proxy_get_shared_data", func(ctx context.Context, mod api.Module, keyData uint32, keySize uint32,
+			returnValueData uint32, returnValueSize uint32, returnCas uint32) uint32 {
+			keyDataPtr := wasmBytePtr(ctx, mod, keyData, keySize)
+			var returnValueHostPtr *byte
+			var returnValueSizePtr int
+			var returnCasPtr uint32
+			ret := uint32(internal.ProxyGetSharedData(keyDataPtr, int(keySize), &returnValueHostPtr, &returnValueSizePtr, &returnCasPtr))
+			copyBytesToWasm(ctx, mod, returnValueHostPtr, returnValueSizePtr, returnValueData, returnValueSize)
+			handleMemoryStatus(mod.Memory().WriteUint32Le(ctx, returnCas, returnCasPtr))
+			return ret
+		}).
+		ExportFunction("proxy_set_shared_data", func(ctx context.Context, mod api.Module, keyData uint32, keySize uint32, valueData uint32, valueSize uint32, cas uint32) uint32 {
+			keyDataPtr := wasmBytePtr(ctx, mod, keyData, keySize)
+			valueDataPtr := wasmBytePtr(ctx, mod, valueData, valueSize)
+			return uint32(internal.ProxySetSharedData(keyDataPtr, int(keySize), valueDataPtr, int(valueSize), cas))
+		}).
+		ExportFunction("proxy_register_shared_queue", func(ctx context.Context, mod api.Module, nameData uint32, nameSize uint32, returnID uint32) uint32 {
+			namePtr := wasmBytePtr(ctx, mod, nameData, nameSize)
+			var returnIDPtr uint32
+			ret := uint32(internal.ProxyRegisterSharedQueue(namePtr, int(nameSize), &returnIDPtr))
+			handleMemoryStatus(mod.Memory().WriteUint32Le(ctx, returnID, returnIDPtr))
+			return ret
+		}).
+		ExportFunction("proxy_resolve_shared_queue", func(ctx context.Context, mod api.Module, vmIDData uint32, vmIDSize uint32, nameData uint32, nameSize uint32, returnID uint32) uint32 {
+			vmID := wasmBytePtr(ctx, mod, vmIDData, vmIDSize)
+			namePtr := wasmBytePtr(ctx, mod, nameData, nameSize)
+			var returnIDPtr uint32
+			ret := uint32(internal.ProxyResolveSharedQueue(vmID, int(vmIDSize), namePtr, int(nameSize), &returnIDPtr))
+			handleMemoryStatus(mod.Memory().WriteUint32Le(ctx, returnID, returnIDPtr))
+			return ret
+		}).
+		ExportFunction("proxy_dequeue_shared_queue", func(ctx context.Context, mod api.Module, queueID uint32, returnValueData uint32, returnValueSize uint32) uint32 {
+			var returnValueHostPtr *byte
+			var returnValueSizePtr int
+			ret := uint32(internal.ProxyDequeueSharedQueue(queueID, &returnValueHostPtr, &returnValueSizePtr))
+			copyBytesToWasm(ctx, mod, returnValueHostPtr, returnValueSizePtr, returnValueData, returnValueSize)
+			return ret
+		}).
+		ExportFunction("proxy_enqueue_shared_queue", func(ctx context.Context, mod api.Module, queueID uint32, valueData uint32, valueSize uint32) uint32 {
+			valuePtr := wasmBytePtr(ctx, mod, valueData, valueSize)
+			return uint32(internal.ProxyEnqueueSharedQueue(queueID, valuePtr, int(valueSize)))
+		}).
+		ExportFunction("proxy_get_header_map_value", func(ctx context.Context, mod api.Module, mapType uint32, keyData uint32, keySize uint32, returnValueData uint32, returnValueSize uint32) uint32 {
+			keyPtr := wasmBytePtr(ctx, mod, keyData, keySize)
+			var retValDataHostPtr *byte
+			var retValSizePtr int
+			ret := uint32(internal.ProxyGetHeaderMapValue(internal.MapType(mapType), keyPtr, int(keySize), &retValDataHostPtr, &retValSizePtr))
+			copyBytesToWasm(ctx, mod, retValDataHostPtr, retValSizePtr, returnValueData, returnValueSize)
+			return ret
+		}).
+		ExportFunction("proxy_add_header_map_value", func(ctx context.Context, mod api.Module, mapType uint32, keyData uint32, keySize uint32, valueData uint32, valueSize uint32) uint32 {
+			keyPtr := wasmBytePtr(ctx, mod, keyData, keySize)
+			valuePtr := wasmBytePtr(ctx, mod, valueData, valueSize)
+			return uint32(internal.ProxyAddHeaderMapValue(internal.MapType(mapType), keyPtr, int(keySize), valuePtr, int(valueSize)))
+		}).
+		ExportFunction("proxy_replace_header_map_value", func(ctx context.Context, mod api.Module, mapType uint32, keyData uint32, keySize uint32, valueData uint32, valueSize uint32) uint32 {
+			keyPtr := wasmBytePtr(ctx, mod, keyData, keySize)
+			valuePtr := wasmBytePtr(ctx, mod, valueData, valueSize)
+			return uint32(internal.ProxyReplaceHeaderMapValue(internal.MapType(mapType), keyPtr, int(keySize), valuePtr, int(valueSize)))
+		}).
+		ExportFunction("proxy_continue_stream", func(streamType uint32) uint32 {
+			return uint32(internal.ProxyContinueStream(internal.StreamType(streamType)))
+		}).
+		ExportFunction("proxy_close_stream", func(streamType uint32) uint32 {
+			return uint32(internal.ProxyCloseStream(internal.StreamType(streamType)))
+		}).
+		ExportFunction("proxy_remove_header_map_value", func(ctx context.Context, mod api.Module, mapType uint32, keyData uint32, keySize uint32) uint32 {
+			keyPtr := wasmBytePtr(ctx, mod, keyData, keySize)
+			return uint32(internal.ProxyRemoveHeaderMapValue(internal.MapType(mapType), keyPtr, int(keySize)))
+		}).
+		ExportFunction("proxy_get_header_map_pairs", func(ctx context.Context, mod api.Module, mapType uint32, returnValueData uint32, returnValueSize uint32) uint32 {
+			var returnValueHostPtr *byte
+			var returnValueSizePtr int
+			ret := uint32(internal.ProxyGetHeaderMapPairs(internal.MapType(mapType), &returnValueHostPtr, &returnValueSizePtr))
+			copyBytesToWasm(ctx, mod, returnValueHostPtr, returnValueSizePtr, returnValueData, returnValueSize)
+			return ret
+		}).
+		ExportFunction("proxy_set_header_map_pairs", func(ctx context.Context, mod api.Module, mapType uint32, mapData uint32, mapSize uint32) uint32 {
+			mapPtr := wasmBytePtr(ctx, mod, mapData, mapSize)
+			return uint32(internal.ProxySetHeaderMapPairs(internal.MapType(mapType), mapPtr, int(mapSize)))
+		}).
+		ExportFunction("proxy_get_buffer_bytes", func(ctx context.Context, mod api.Module, bufferType uint32, start uint32, maxSize uint32, returnBufferData uint32, returnBufferSize uint32) uint32 {
+			var returnBufferDataHostPtr *byte
+			var returnBufferSizePtr int
+			ret := uint32(internal.ProxyGetBufferBytes(internal.BufferType(bufferType), int(start), int(maxSize), &returnBufferDataHostPtr, &returnBufferSizePtr))
+			copyBytesToWasm(ctx, mod, returnBufferDataHostPtr, returnBufferSizePtr, returnBufferData, returnBufferSize)
+			return ret
+		}).
+		ExportFunction("proxy_set_buffer_bytes", func(ctx context.Context, mod api.Module, bufferType uint32, start uint32, maxSize uint32, bufferData uint32, bufferSize uint32) uint32 {
+			bufferPtr := wasmBytePtr(ctx, mod, bufferData, bufferSize)
+			return uint32(internal.ProxySetBufferBytes(internal.BufferType(bufferType), int(start), int(maxSize), bufferPtr, int(bufferSize)))
+		}).
+		ExportFunction("proxy_http_call", func(ctx context.Context, mod api.Module, upstreamData uint32, upstreamSize uint32, headerData uint32, headerSize uint32, bodyData uint32, bodySize uint32, trailersData uint32, trailersSize uint32, timeout uint32, calloutIDPtr uint32) uint32 {
+			upstreamPtr := wasmBytePtr(ctx, mod, upstreamData, upstreamSize)
+			headerPtr := wasmBytePtr(ctx, mod, headerData, headerSize)
+			bodyPtr := wasmBytePtr(ctx, mod, bodyData, bodySize)
+			trailersPtr := wasmBytePtr(ctx, mod, trailersData, trailersSize)
+			var calloutID uint32
+			ret := uint32(internal.ProxyHttpCall(upstreamPtr, int(upstreamSize), headerPtr, int(headerSize), bodyPtr, int(bodySize), trailersPtr, int(trailersSize), timeout, &calloutID))
+			handleMemoryStatus(mod.Memory().WriteUint32Le(ctx, calloutIDPtr, calloutID))
+			return ret
+		}).
+		ExportFunction("proxy_call_foreign_function", func(ctx context.Context, mod api.Module, funcNamePtr uint32, funcNameSize uint32, paramPtr uint32, paramSize uint32, returnData uint32, returnSize uint32) uint32 {
+			funcName := wasmBytePtr(ctx, mod, funcNamePtr, funcNameSize)
+			paramHostPtr := wasmBytePtr(ctx, mod, paramPtr, paramSize)
+			var returnDataHostPtr *byte
+			var returnDataSizePtr int
+			ret := uint32(internal.ProxyCallForeignFunction(funcName, int(funcNameSize), paramHostPtr, int(paramSize), &returnDataHostPtr, &returnDataSizePtr))
+			copyBytesToWasm(ctx, mod, returnDataHostPtr, returnDataSizePtr, returnData, returnSize)
+			return ret
+		}).
+		ExportFunction("proxy_set_tick_period_milliseconds", func(period uint32) uint32 {
+			return uint32(internal.ProxySetTickPeriodMilliseconds(period))
+		}).
+		ExportFunction("proxy_set_effective_context", func(contextID uint32) uint32 {
+			return uint32(internal.ProxySetEffectiveContext(contextID))
+		}).
+		ExportFunction("proxy_done", func() uint32 {
+			return uint32(internal.ProxyDone())
+		}).
+		ExportFunction("proxy_define_metric", func(ctx context.Context, mod api.Module, metricType uint32, metricNameData uint32, metricNameSize uint32, returnMetricIDPtr uint32) uint32 {
+			metricName := wasmBytePtr(ctx, mod, metricNameData, metricNameSize)
+			var returnMetricID uint32
+			ret := uint32(internal.ProxyDefineMetric(internal.MetricType(metricType), metricName, int(metricNameSize), &returnMetricID))
+			handleMemoryStatus(mod.Memory().WriteUint32Le(ctx, returnMetricIDPtr, returnMetricID))
+			return ret
+		}).
+		ExportFunction("proxy_increment_metric", func(metricID uint32, offset int64) uint32 {
+			return uint32(internal.ProxyIncrementMetric(metricID, offset))
+		}).
+		ExportFunction("proxy_record_metric", func(metricID uint32, value uint64) uint32 {
+			return uint32(internal.ProxyRecordMetric(metricID, value))
+		}).
+		ExportFunction("proxy_get_metric", func(ctx context.Context, mod api.Module, metricID uint32, returnMetricValue uint32) uint32 {
+			var returnMetricValuePtr uint64
+			ret := uint32(internal.ProxyGetMetric(metricID, &returnMetricValuePtr))
+			handleMemoryStatus(mod.Memory().WriteUint64Le(ctx, returnMetricValue, returnMetricValuePtr))
+			return ret
+		}).
+		Instantiate(nil, r)
+	return err
+}


### PR DESCRIPTION
Signed-off-by: Anuraag Agrawal <anuraaga@gmail.com>

@mathetake This is still WIP for tests, but it would be good to get an initial review on the general approach. For testing, is it appropriate to compile all the `example`s to wasm and run their tests both with go and wasm runners?

Can see usage in https://github.com/anuraaga/coraza-wasm-filter/compare/main...anuraaga:coraza-wasm-filter:wasm-unit-tests?expand=1