### PR TITLE
Add build tag that prints timings of ABI method execution.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ build.examples:
 .PHONY: test
 test:
 	@go test $(shell go list ./... | grep -v e2e)
+	@go test -tags "proxywasm_timing" ./proxywasm/proxytest
 
 .PHONY: test.examples
 test.examples:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ and we run end-to-end tests with multiple versions of Envoy and Envoy-based [ist
 
 Please refer to [workflow.yaml](.github/workflows/workflow.yaml) for which version is used for End-to-End tests.
 
+## Build tags
+
+The following build tags can be used to customize the behavior of the built plugin:
+
+- `proxywasm_timing`: Enables logging of time spent in invocation of the plugin's exported functions. This can be useful for debugging performance issues.
+
 ## Contributing
 
 We welcome contributions from the community! See [CONTRIBUTING.md](doc/CONTRIBUTING.md) for how to contribute to this repository.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -334,7 +333,7 @@ func Test_json_validation(t *testing.T) {
 		}
 		defer res.Body.Close()
 
-		_, err = io.Copy(ioutil.Discard, res.Body)
+		_, err = io.Copy(io.Discard, res.Body)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusForbidden, res.StatusCode)
 
@@ -348,7 +347,7 @@ func Test_json_validation(t *testing.T) {
 		}
 		defer res.Body.Close()
 
-		_, err = io.Copy(ioutil.Discard, res.Body)
+		_, err = io.Copy(io.Discard, res.Body)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, res.StatusCode)
 

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -540,19 +540,19 @@ func SetSharedData(key string, data []byte, cas uint32) error {
 // Note: if the target propety is map-type, use GetPropetyMap instead. This GetProperty returns
 // raw un-serialized bytes for such properties. For example, if you have the metadata as
 //
-//  clusters:
-//  - name: web_service
-//    metadata:
-//     filter_metadata:
-//       foo:
-//         my_value: '1234'
-//         my_map:
-//           k1: v1
-//           k2: v2
+//	clusters:
+//	- name: web_service
+//	  metadata:
+//	   filter_metadata:
+//	     foo:
+//	       my_value: '1234'
+//	       my_map:
+//	         k1: v1
+//	         k2: v2
 //
 // Then,
-//  * use GetPropetyMap for {"cluster_metadata", "filter_metadata", "foo", "my_map"}.
-//  * use GetProperty   for {"cluster_metadata", "filter_metadata", "foo", "my_value"}.
+//   - use GetPropetyMap for {"cluster_metadata", "filter_metadata", "foo", "my_map"}.
+//   - use GetProperty   for {"cluster_metadata", "filter_metadata", "foo", "my_value"}.
 //
 // Note: you cannot get the raw bytes of protobuf. For example, accessing {"cluster_metadata", "filter_data", "foo"}) doesn't
 // returns the protobuf bytes, but instead this returns the serialized map of "foo". Therefore, we recommend to access individual

--- a/proxywasm/internal/abi_callback_alloc.go
+++ b/proxywasm/internal/abi_callback_alloc.go
@@ -16,12 +16,10 @@ package internal
 
 import "time"
 
-// nolint
-//
 //export proxy_on_memory_allocate
 func proxyOnMemoryAllocate(size uint) *byte {
 	if recordTiming {
-		logTiming("proxyOnMemoryAllocate", time.Now())
+		defer logTiming("proxyOnMemoryAllocate", time.Now())
 	}
 	buf := make([]byte, size)
 	return &buf[0]

--- a/proxywasm/internal/abi_callback_configuration.go
+++ b/proxywasm/internal/abi_callback_configuration.go
@@ -23,7 +23,7 @@ import (
 //export proxy_on_vm_start
 func proxyOnVMStart(_ uint32, vmConfigurationSize int) types.OnVMStartStatus {
 	if recordTiming {
-		logTiming("proxyOnVMStart", time.Now())
+		defer logTiming("proxyOnVMStart", time.Now())
 	}
 	return currentState.vmContext.OnVMStart(vmConfigurationSize)
 }
@@ -31,7 +31,7 @@ func proxyOnVMStart(_ uint32, vmConfigurationSize int) types.OnVMStartStatus {
 //export proxy_on_configure
 func proxyOnConfigure(pluginContextID uint32, pluginConfigurationSize int) types.OnPluginStartStatus {
 	if recordTiming {
-		logTiming("proxyOnConfigure", time.Now())
+		defer logTiming("proxyOnConfigure", time.Now())
 	}
 	ctx, ok := currentState.pluginContexts[pluginContextID]
 	if !ok {

--- a/proxywasm/internal/abi_callback_configuration.go
+++ b/proxywasm/internal/abi_callback_configuration.go
@@ -15,16 +15,24 @@
 package internal
 
 import (
+	"time"
+
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
 )
 
 //export proxy_on_vm_start
 func proxyOnVMStart(_ uint32, vmConfigurationSize int) types.OnVMStartStatus {
+	if recordTiming {
+		logTiming("proxyOnVMStart", time.Now())
+	}
 	return currentState.vmContext.OnVMStart(vmConfigurationSize)
 }
 
 //export proxy_on_configure
 func proxyOnConfigure(pluginContextID uint32, pluginConfigurationSize int) types.OnPluginStartStatus {
+	if recordTiming {
+		logTiming("proxyOnConfigure", time.Now())
+	}
 	ctx, ok := currentState.pluginContexts[pluginContextID]
 	if !ok {
 		panic("invalid context on proxy_on_configure")

--- a/proxywasm/internal/abi_callback_configuration_test.go
+++ b/proxywasm/internal/abi_callback_configuration_test.go
@@ -62,6 +62,9 @@ func Test_proxyOnVMStart(t *testing.T) {
 	require.True(t, vmContext.onVMStartCalled)
 	require.Equal(t, uint32(0), currentState.activeContextID)
 
+	// Allocate memory
+	require.NotNil(t, proxyOnMemoryAllocate(100))
+
 	// Create plugin context.
 	pluginContextID := uint32(100)
 	proxyOnContextCreate(pluginContextID, 0)

--- a/proxywasm/internal/abi_callback_configuration_test.go
+++ b/proxywasm/internal/abi_callback_configuration_test.go
@@ -62,6 +62,9 @@ func Test_proxyOnVMStart(t *testing.T) {
 	require.True(t, vmContext.onVMStartCalled)
 	require.Equal(t, uint32(0), currentState.activeContextID)
 
+	// Check ABI version. There is no return value so just make sure it doesn't panic.
+	proxyABIVersion()
+
 	// Allocate memory
 	require.NotNil(t, proxyOnMemoryAllocate(100))
 

--- a/proxywasm/internal/abi_callback_l4.go
+++ b/proxywasm/internal/abi_callback_l4.go
@@ -23,7 +23,7 @@ import (
 //export proxy_on_new_connection
 func proxyOnNewConnection(contextID uint32) types.Action {
 	if recordTiming {
-		logTiming("proxyOnNewConnection", time.Now())
+		defer logTiming("proxyOnNewConnection", time.Now())
 	}
 	ctx, ok := currentState.tcpContexts[contextID]
 	if !ok {
@@ -36,7 +36,7 @@ func proxyOnNewConnection(contextID uint32) types.Action {
 //export proxy_on_downstream_data
 func proxyOnDownstreamData(contextID uint32, dataSize int, endOfStream bool) types.Action {
 	if recordTiming {
-		logTiming("proxyOnDownstreamData", time.Now())
+		defer logTiming("proxyOnDownstreamData", time.Now())
 	}
 	ctx, ok := currentState.tcpContexts[contextID]
 	if !ok {
@@ -49,7 +49,7 @@ func proxyOnDownstreamData(contextID uint32, dataSize int, endOfStream bool) typ
 //export proxy_on_downstream_connection_close
 func proxyOnDownstreamConnectionClose(contextID uint32, pType types.PeerType) {
 	if recordTiming {
-		logTiming("proxyOnDownstreamConnectionClose", time.Now())
+		defer logTiming("proxyOnDownstreamConnectionClose", time.Now())
 	}
 	ctx, ok := currentState.tcpContexts[contextID]
 	if !ok {
@@ -62,7 +62,7 @@ func proxyOnDownstreamConnectionClose(contextID uint32, pType types.PeerType) {
 //export proxy_on_upstream_data
 func proxyOnUpstreamData(contextID uint32, dataSize int, endOfStream bool) types.Action {
 	if recordTiming {
-		logTiming("proxyOnUpstreamData", time.Now())
+		defer logTiming("proxyOnUpstreamData", time.Now())
 	}
 	ctx, ok := currentState.tcpContexts[contextID]
 	if !ok {
@@ -75,7 +75,7 @@ func proxyOnUpstreamData(contextID uint32, dataSize int, endOfStream bool) types
 //export proxy_on_upstream_connection_close
 func proxyOnUpstreamConnectionClose(contextID uint32, pType types.PeerType) {
 	if recordTiming {
-		logTiming("proxyOnUpstreamConnectionClose", time.Now())
+		defer logTiming("proxyOnUpstreamConnectionClose", time.Now())
 	}
 	ctx, ok := currentState.tcpContexts[contextID]
 	if !ok {

--- a/proxywasm/internal/abi_callback_l4.go
+++ b/proxywasm/internal/abi_callback_l4.go
@@ -14,10 +14,17 @@
 
 package internal
 
-import "github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+import (
+	"time"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
 
 //export proxy_on_new_connection
 func proxyOnNewConnection(contextID uint32) types.Action {
+	if recordTiming {
+		logTiming("proxyOnNewConnection", time.Now())
+	}
 	ctx, ok := currentState.tcpContexts[contextID]
 	if !ok {
 		panic("invalid context")
@@ -28,6 +35,9 @@ func proxyOnNewConnection(contextID uint32) types.Action {
 
 //export proxy_on_downstream_data
 func proxyOnDownstreamData(contextID uint32, dataSize int, endOfStream bool) types.Action {
+	if recordTiming {
+		logTiming("proxyOnDownstreamData", time.Now())
+	}
 	ctx, ok := currentState.tcpContexts[contextID]
 	if !ok {
 		panic("invalid context")
@@ -38,6 +48,9 @@ func proxyOnDownstreamData(contextID uint32, dataSize int, endOfStream bool) typ
 
 //export proxy_on_downstream_connection_close
 func proxyOnDownstreamConnectionClose(contextID uint32, pType types.PeerType) {
+	if recordTiming {
+		logTiming("proxyOnDownstreamConnectionClose", time.Now())
+	}
 	ctx, ok := currentState.tcpContexts[contextID]
 	if !ok {
 		panic("invalid context")
@@ -48,6 +61,9 @@ func proxyOnDownstreamConnectionClose(contextID uint32, pType types.PeerType) {
 
 //export proxy_on_upstream_data
 func proxyOnUpstreamData(contextID uint32, dataSize int, endOfStream bool) types.Action {
+	if recordTiming {
+		logTiming("proxyOnUpstreamData", time.Now())
+	}
 	ctx, ok := currentState.tcpContexts[contextID]
 	if !ok {
 		panic("invalid context")
@@ -58,6 +74,9 @@ func proxyOnUpstreamData(contextID uint32, dataSize int, endOfStream bool) types
 
 //export proxy_on_upstream_connection_close
 func proxyOnUpstreamConnectionClose(contextID uint32, pType types.PeerType) {
+	if recordTiming {
+		logTiming("proxyOnUpstreamConnectionClose", time.Now())
+	}
 	ctx, ok := currentState.tcpContexts[contextID]
 	if !ok {
 		panic("invalid context")

--- a/proxywasm/internal/abi_callback_l7.go
+++ b/proxywasm/internal/abi_callback_l7.go
@@ -23,7 +23,7 @@ import (
 //export proxy_on_request_headers
 func proxyOnRequestHeaders(contextID uint32, numHeaders int, endOfStream bool) types.Action {
 	if recordTiming {
-		logTiming("proxyOnRequestHeaders", time.Now())
+		defer logTiming("proxyOnRequestHeaders", time.Now())
 	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
@@ -37,7 +37,7 @@ func proxyOnRequestHeaders(contextID uint32, numHeaders int, endOfStream bool) t
 //export proxy_on_request_body
 func proxyOnRequestBody(contextID uint32, bodySize int, endOfStream bool) types.Action {
 	if recordTiming {
-		logTiming("proxyOnRequestBody", time.Now())
+		defer logTiming("proxyOnRequestBody", time.Now())
 	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
@@ -50,7 +50,7 @@ func proxyOnRequestBody(contextID uint32, bodySize int, endOfStream bool) types.
 //export proxy_on_request_trailers
 func proxyOnRequestTrailers(contextID uint32, numTrailers int) types.Action {
 	if recordTiming {
-		logTiming("proxyOnRequestTrailers", time.Now())
+		defer logTiming("proxyOnRequestTrailers", time.Now())
 	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
@@ -63,7 +63,7 @@ func proxyOnRequestTrailers(contextID uint32, numTrailers int) types.Action {
 //export proxy_on_response_headers
 func proxyOnResponseHeaders(contextID uint32, numHeaders int, endOfStream bool) types.Action {
 	if recordTiming {
-		logTiming("proxyOnResponseHeaders", time.Now())
+		defer logTiming("proxyOnResponseHeaders", time.Now())
 	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
@@ -76,7 +76,7 @@ func proxyOnResponseHeaders(contextID uint32, numHeaders int, endOfStream bool) 
 //export proxy_on_response_body
 func proxyOnResponseBody(contextID uint32, bodySize int, endOfStream bool) types.Action {
 	if recordTiming {
-		logTiming("proxyOnResponseBody", time.Now())
+		defer logTiming("proxyOnResponseBody", time.Now())
 	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
@@ -89,7 +89,7 @@ func proxyOnResponseBody(contextID uint32, bodySize int, endOfStream bool) types
 //export proxy_on_response_trailers
 func proxyOnResponseTrailers(contextID uint32, numTrailers int) types.Action {
 	if recordTiming {
-		logTiming("proxyOnResponseTrailers", time.Now())
+		defer logTiming("proxyOnResponseTrailers", time.Now())
 	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
@@ -102,7 +102,7 @@ func proxyOnResponseTrailers(contextID uint32, numTrailers int) types.Action {
 //export proxy_on_http_call_response
 func proxyOnHttpCallResponse(pluginContextID, calloutID uint32, numHeaders, bodySize, numTrailers int) {
 	if recordTiming {
-		logTiming("proxyOnHttpCallResponse", time.Now())
+		defer logTiming("proxyOnHttpCallResponse", time.Now())
 	}
 	root, ok := currentState.pluginContexts[pluginContextID]
 	if !ok {

--- a/proxywasm/internal/abi_callback_l7.go
+++ b/proxywasm/internal/abi_callback_l7.go
@@ -15,11 +15,16 @@
 package internal
 
 import (
+	"time"
+
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
 )
 
 //export proxy_on_request_headers
 func proxyOnRequestHeaders(contextID uint32, numHeaders int, endOfStream bool) types.Action {
+	if recordTiming {
+		logTiming("proxyOnRequestHeaders", time.Now())
+	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
 		panic("invalid context on proxy_on_request_headers")
@@ -31,6 +36,9 @@ func proxyOnRequestHeaders(contextID uint32, numHeaders int, endOfStream bool) t
 
 //export proxy_on_request_body
 func proxyOnRequestBody(contextID uint32, bodySize int, endOfStream bool) types.Action {
+	if recordTiming {
+		logTiming("proxyOnRequestBody", time.Now())
+	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
 		panic("invalid context on proxy_on_request_body")
@@ -41,6 +49,9 @@ func proxyOnRequestBody(contextID uint32, bodySize int, endOfStream bool) types.
 
 //export proxy_on_request_trailers
 func proxyOnRequestTrailers(contextID uint32, numTrailers int) types.Action {
+	if recordTiming {
+		logTiming("proxyOnRequestTrailers", time.Now())
+	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
 		panic("invalid context on proxy_on_request_trailers")
@@ -51,6 +62,9 @@ func proxyOnRequestTrailers(contextID uint32, numTrailers int) types.Action {
 
 //export proxy_on_response_headers
 func proxyOnResponseHeaders(contextID uint32, numHeaders int, endOfStream bool) types.Action {
+	if recordTiming {
+		logTiming("proxyOnResponseHeaders", time.Now())
+	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
 		panic("invalid context id on proxy_on_response_headers")
@@ -61,6 +75,9 @@ func proxyOnResponseHeaders(contextID uint32, numHeaders int, endOfStream bool) 
 
 //export proxy_on_response_body
 func proxyOnResponseBody(contextID uint32, bodySize int, endOfStream bool) types.Action {
+	if recordTiming {
+		logTiming("proxyOnResponseBody", time.Now())
+	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
 		panic("invalid context id on proxy_on_response_headers")
@@ -71,6 +88,9 @@ func proxyOnResponseBody(contextID uint32, bodySize int, endOfStream bool) types
 
 //export proxy_on_response_trailers
 func proxyOnResponseTrailers(contextID uint32, numTrailers int) types.Action {
+	if recordTiming {
+		logTiming("proxyOnResponseTrailers", time.Now())
+	}
 	ctx, ok := currentState.httpContexts[contextID]
 	if !ok {
 		panic("invalid context id on proxy_on_response_headers")
@@ -81,6 +101,9 @@ func proxyOnResponseTrailers(contextID uint32, numTrailers int) types.Action {
 
 //export proxy_on_http_call_response
 func proxyOnHttpCallResponse(pluginContextID, calloutID uint32, numHeaders, bodySize, numTrailers int) {
+	if recordTiming {
+		logTiming("proxyOnHttpCallResponse", time.Now())
+	}
 	root, ok := currentState.pluginContexts[pluginContextID]
 	if !ok {
 		panic("http_call_response on invalid plugin context")

--- a/proxywasm/internal/abi_callback_lifecycle.go
+++ b/proxywasm/internal/abi_callback_lifecycle.go
@@ -14,8 +14,13 @@
 
 package internal
 
+import "time"
+
 //export proxy_on_context_create
 func proxyOnContextCreate(contextID uint32, pluginContextID uint32) {
+	if recordTiming {
+		logTiming("proxyOnContextCreate", time.Now())
+	}
 	if pluginContextID == 0 {
 		currentState.createPluginContext(contextID)
 	} else if currentState.createHttpContext(contextID, pluginContextID) {
@@ -27,6 +32,9 @@ func proxyOnContextCreate(contextID uint32, pluginContextID uint32) {
 
 //export proxy_on_log
 func proxyOnLog(contextID uint32) {
+	if recordTiming {
+		logTiming("proxyOnLog", time.Now())
+	}
 	if ctx, ok := currentState.tcpContexts[contextID]; ok {
 		currentState.setActiveContextID(contextID)
 		ctx.OnStreamDone()
@@ -38,6 +46,9 @@ func proxyOnLog(contextID uint32) {
 
 //export proxy_on_done
 func proxyOnDone(contextID uint32) bool {
+	if recordTiming {
+		logTiming("proxyOnDone", time.Now())
+	}
 	if ctx, ok := currentState.pluginContexts[contextID]; ok {
 		currentState.setActiveContextID(contextID)
 		return ctx.context.OnPluginDone()
@@ -47,6 +58,9 @@ func proxyOnDone(contextID uint32) bool {
 
 //export proxy_on_delete
 func proxyOnDelete(contextID uint32) {
+	if recordTiming {
+		logTiming("proxyOnDelete", time.Now())
+	}
 	delete(currentState.contextIDToRootID, contextID)
 	if _, ok := currentState.tcpContexts[contextID]; ok {
 		delete(currentState.tcpContexts, contextID)

--- a/proxywasm/internal/abi_callback_lifecycle.go
+++ b/proxywasm/internal/abi_callback_lifecycle.go
@@ -19,7 +19,7 @@ import "time"
 //export proxy_on_context_create
 func proxyOnContextCreate(contextID uint32, pluginContextID uint32) {
 	if recordTiming {
-		logTiming("proxyOnContextCreate", time.Now())
+		defer logTiming("proxyOnContextCreate", time.Now())
 	}
 	if pluginContextID == 0 {
 		currentState.createPluginContext(contextID)
@@ -33,7 +33,7 @@ func proxyOnContextCreate(contextID uint32, pluginContextID uint32) {
 //export proxy_on_log
 func proxyOnLog(contextID uint32) {
 	if recordTiming {
-		logTiming("proxyOnLog", time.Now())
+		defer logTiming("proxyOnLog", time.Now())
 	}
 	if ctx, ok := currentState.tcpContexts[contextID]; ok {
 		currentState.setActiveContextID(contextID)
@@ -47,7 +47,7 @@ func proxyOnLog(contextID uint32) {
 //export proxy_on_done
 func proxyOnDone(contextID uint32) bool {
 	if recordTiming {
-		logTiming("proxyOnDone", time.Now())
+		defer logTiming("proxyOnDone", time.Now())
 	}
 	if ctx, ok := currentState.pluginContexts[contextID]; ok {
 		currentState.setActiveContextID(contextID)
@@ -59,7 +59,7 @@ func proxyOnDone(contextID uint32) bool {
 //export proxy_on_delete
 func proxyOnDelete(contextID uint32) {
 	if recordTiming {
-		logTiming("proxyOnDelete", time.Now())
+		defer logTiming("proxyOnDelete", time.Now())
 	}
 	delete(currentState.contextIDToRootID, contextID)
 	if _, ok := currentState.tcpContexts[contextID]; ok {

--- a/proxywasm/internal/abi_callback_queue.go
+++ b/proxywasm/internal/abi_callback_queue.go
@@ -19,7 +19,7 @@ import "time"
 //export proxy_on_queue_ready
 func proxyOnQueueReady(contextID, queueID uint32) {
 	if recordTiming {
-		logTiming("proxyOnQueueReady", time.Now())
+		defer logTiming("proxyOnQueueReady", time.Now())
 	}
 	ctx, ok := currentState.pluginContexts[contextID]
 	if !ok {

--- a/proxywasm/internal/abi_callback_queue.go
+++ b/proxywasm/internal/abi_callback_queue.go
@@ -14,8 +14,13 @@
 
 package internal
 
+import "time"
+
 //export proxy_on_queue_ready
 func proxyOnQueueReady(contextID, queueID uint32) {
+	if recordTiming {
+		logTiming("proxyOnQueueReady", time.Now())
+	}
 	ctx, ok := currentState.pluginContexts[contextID]
 	if !ok {
 		panic("invalid context")

--- a/proxywasm/internal/abi_callback_timers.go
+++ b/proxywasm/internal/abi_callback_timers.go
@@ -14,8 +14,13 @@
 
 package internal
 
+import "time"
+
 //export proxy_on_tick
 func proxyOnTick(pluginContextID uint32) {
+	if recordTiming {
+		logTiming("proxyOnTick", time.Now())
+	}
 	ctx, ok := currentState.pluginContexts[pluginContextID]
 	if !ok {
 		panic("invalid root_context_id")

--- a/proxywasm/internal/abi_callback_timers.go
+++ b/proxywasm/internal/abi_callback_timers.go
@@ -19,7 +19,7 @@ import "time"
 //export proxy_on_tick
 func proxyOnTick(pluginContextID uint32) {
 	if recordTiming {
-		logTiming("proxyOnTick", time.Now())
+		defer logTiming("proxyOnTick", time.Now())
 	}
 	ctx, ok := currentState.pluginContexts[pluginContextID]
 	if !ok {

--- a/proxywasm/internal/abi_callback_version.go
+++ b/proxywasm/internal/abi_callback_version.go
@@ -21,6 +21,6 @@ import "time"
 //export proxy_abi_version_0_2_0
 func proxyABIVersion() {
 	if recordTiming {
-		logTiming("proxyABIVersion", time.Now())
+		defer logTiming("proxyABIVersion", time.Now())
 	}
 }

--- a/proxywasm/internal/abi_callback_version.go
+++ b/proxywasm/internal/abi_callback_version.go
@@ -14,6 +14,13 @@
 
 package internal
 
-//nolint
+import "time"
+
+// nolint
+//
 //export proxy_abi_version_0_2_0
-func proxyABIVersion() {}
+func proxyABIVersion() {
+	if recordTiming {
+		logTiming("proxyABIVersion", time.Now())
+	}
+}

--- a/proxywasm/internal/abi_callback_version.go
+++ b/proxywasm/internal/abi_callback_version.go
@@ -16,8 +16,6 @@ package internal
 
 import "time"
 
-// nolint
-//
 //export proxy_abi_version_0_2_0
 func proxyABIVersion() {
 	if recordTiming {

--- a/proxywasm/internal/timing_off.go
+++ b/proxywasm/internal/timing_off.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Tetrate
+// Copyright 2020-2022 Tetrate
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !proxywasm_timing
+
 package internal
 
 import "time"
 
-// nolint
-//
-//export proxy_on_memory_allocate
-func proxyOnMemoryAllocate(size uint) *byte {
-	if recordTiming {
-		logTiming("proxyOnMemoryAllocate", time.Now())
-	}
-	buf := make([]byte, size)
-	return &buf[0]
+// When no build tag is specified, we do record print timing information so set this to false.
+const recordTiming = false
+
+func logTiming(msg string, start time.Time) {
+	panic("BUG: logTiming should not be called when timing is disabled")
 }

--- a/proxywasm/internal/timing_on.go
+++ b/proxywasm/internal/timing_on.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Tetrate
+// Copyright 2020-2022 Tetrate
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build proxywasm_timing
+
 package internal
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
-// nolint
-//
-//export proxy_on_memory_allocate
-func proxyOnMemoryAllocate(size uint) *byte {
-	if recordTiming {
-		logTiming("proxyOnMemoryAllocate", time.Now())
-	}
-	buf := make([]byte, size)
-	return &buf[0]
+// When the build tag is specified, we record timing information so set this to true.
+const recordTiming = true
+
+func logTiming(msg string, start time.Time) {
+	f := fmt.Sprintf("%s took %s", msg, time.Since(start))
+	ProxyLog(LogLevelDebug, StringBytePtr(f), len(f))
 }

--- a/proxywasm/internal/timing_on.go
+++ b/proxywasm/internal/timing_on.go
@@ -25,6 +25,9 @@ import (
 const recordTiming = true
 
 func logTiming(msg string, start time.Time) {
+	if !recordTiming {
+		panic("BUG: logTiming should not be called when timing is disabled")
+	}
 	f := fmt.Sprintf("%s took %s", msg, time.Since(start))
 	ProxyLog(LogLevelDebug, StringBytePtr(f), len(f))
 }

--- a/proxywasm/proxytest/timing_off_test.go
+++ b/proxywasm/proxytest/timing_off_test.go
@@ -1,0 +1,86 @@
+//go:build !proxywasm_timing
+
+package proxytest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+type noopPlugin struct {
+	types.DefaultVMContext
+	tcp bool
+}
+
+// NewPluginContext implements the same method on types.DefaultVMContext.
+func (p *noopPlugin) NewPluginContext(uint32) types.PluginContext {
+	return &noopPluginContext{tcp: p.tcp}
+}
+
+type noopPluginContext struct {
+	types.DefaultPluginContext
+	tcp bool
+}
+
+// NewHttpContext implements the same method on types.DefaultPluginContext.
+func (p *noopPluginContext) NewHttpContext(uint32) types.HttpContext {
+	if !p.tcp {
+		return &noopHttpContext{}
+	}
+	return nil
+}
+
+// NewTcpContext implements the same method on types.DefaultPluginContext.
+func (p *noopPluginContext) NewTcpContext(uint32) types.TcpContext {
+	if p.tcp {
+		return &noopTcpContext{}
+	}
+	return nil
+}
+
+type noopHttpContext struct {
+	types.DefaultHttpContext
+}
+
+type noopTcpContext struct {
+	types.DefaultTcpContext
+}
+
+// Execute lifecycle methods, there should be no logs for the no-op plugin.
+func TestTimingOff(t *testing.T) {
+	t.Run("http", func(t *testing.T) {
+		host, reset := NewHostEmulator(NewEmulatorOption().WithVMContext(&noopPlugin{}))
+		defer reset()
+
+		require.Equal(t, types.OnPluginStartStatusOK, host.StartPlugin())
+		id := host.InitializeHttpContext()
+
+		require.Equal(t, types.ActionContinue, host.CallOnRequestHeaders(id, nil, false))
+		require.Equal(t, types.ActionContinue, host.CallOnRequestBody(id, nil, false))
+		require.Equal(t, types.ActionContinue, host.CallOnRequestTrailers(id, nil))
+		require.Equal(t, types.ActionContinue, host.CallOnResponseHeaders(id, nil, false))
+		require.Equal(t, types.ActionContinue, host.CallOnResponseBody(id, nil, false))
+		require.Equal(t, types.ActionContinue, host.CallOnResponseTrailers(id, nil))
+		host.CompleteHttpContext(id)
+
+		require.Empty(t, host.GetDebugLogs())
+	})
+
+	t.Run("tcp", func(t *testing.T) {
+		host, reset := NewHostEmulator(NewEmulatorOption().WithVMContext(&noopPlugin{tcp: true}))
+		defer reset()
+
+		require.Equal(t, types.OnPluginStartStatusOK, host.StartPlugin())
+		id, action := host.InitializeConnection()
+		require.Equal(t, types.ActionContinue, action)
+
+		require.Equal(t, types.ActionContinue, host.CallOnDownstreamData(id, nil))
+		require.Equal(t, types.ActionContinue, host.CallOnUpstreamData(id, nil))
+		host.CompleteConnection(id)
+
+		require.Empty(t, host.GetDebugLogs())
+	})
+}

--- a/proxywasm/proxytest/timing_on_test.go
+++ b/proxywasm/proxytest/timing_on_test.go
@@ -5,6 +5,7 @@ package proxytest
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -110,8 +111,13 @@ func requireLogged(t *testing.T, msg string, logs []string) {
 	re := regexp.MustCompile(fmt.Sprintf(`%s took \d+`, msg))
 	for _, l := range logs {
 		if re.MatchString(l) {
+			// While we can't make reliable assertions on the actual time took, it is inconceivable to have a time of
+			// 0, though bugs like forgetting "defer" might cause it. So do a special check for it.
+			if strings.Contains(l, "took 0s") {
+				require.Fail(t, "unexpected log", "times should be non-zero: %s", l)
+			}
 			return
 		}
 	}
-	require.Failf(t, "expected log", "expected log %s, got %v", msg, logs)
+	require.Failf(t, "unexpected log", "expected log %s, got %v", msg, logs)
 }

--- a/proxywasm/proxytest/timing_on_test.go
+++ b/proxywasm/proxytest/timing_on_test.go
@@ -5,7 +5,6 @@ package proxytest
 import (
 	"fmt"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -113,9 +112,7 @@ func requireLogged(t *testing.T, msg string, logs []string) {
 		if re.MatchString(l) {
 			// While we can't make reliable assertions on the actual time took, it is inconceivable to have a time of
 			// 0, though bugs like forgetting "defer" might cause it. So do a special check for it.
-			if strings.Contains(l, "took 0s") {
-				require.Fail(t, "unexpected log", "times should be non-zero: %s", l)
-			}
+			require.NotContains(t, l, "took 0s")
 			return
 		}
 	}

--- a/proxywasm/proxytest/timing_on_test.go
+++ b/proxywasm/proxytest/timing_on_test.go
@@ -1,0 +1,117 @@
+//go:build proxywasm_timing
+
+package proxytest
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+type noopPlugin struct {
+	types.DefaultVMContext
+	tcp bool
+}
+
+// NewPluginContext implements the same method on types.DefaultVMContext.
+func (p *noopPlugin) NewPluginContext(uint32) types.PluginContext {
+	return &noopPluginContext{tcp: p.tcp}
+}
+
+type noopPluginContext struct {
+	types.DefaultPluginContext
+	tcp bool
+}
+
+// NewHttpContext implements the same method on types.DefaultPluginContext.
+func (p *noopPluginContext) NewHttpContext(uint32) types.HttpContext {
+	if !p.tcp {
+		return &noopHttpContext{}
+	}
+	return nil
+}
+
+// NewTcpContext implements the same method on types.DefaultPluginContext.
+func (p *noopPluginContext) NewTcpContext(uint32) types.TcpContext {
+	if p.tcp {
+		return &noopTcpContext{}
+	}
+	return nil
+}
+
+type noopHttpContext struct {
+	types.DefaultHttpContext
+}
+
+type noopTcpContext struct {
+	types.DefaultTcpContext
+}
+
+// Execute lifecycle methods, there should be logs for the no-op plugin.
+func TestTimingOn(t *testing.T) {
+	t.Run("http", func(t *testing.T) {
+		host, reset := NewHostEmulator(NewEmulatorOption().WithVMContext(&noopPlugin{}))
+		defer reset()
+
+		require.Equal(t, types.OnPluginStartStatusOK, host.StartPlugin())
+		id := host.InitializeHttpContext()
+
+		require.Equal(t, types.ActionContinue, host.CallOnRequestHeaders(id, nil, false))
+		require.Equal(t, types.ActionContinue, host.CallOnRequestBody(id, nil, false))
+		require.Equal(t, types.ActionContinue, host.CallOnRequestTrailers(id, nil))
+		require.Equal(t, types.ActionContinue, host.CallOnResponseHeaders(id, nil, false))
+		require.Equal(t, types.ActionContinue, host.CallOnResponseBody(id, nil, false))
+		require.Equal(t, types.ActionContinue, host.CallOnResponseTrailers(id, nil))
+		host.CompleteHttpContext(id)
+
+		host.GetDebugLogs()
+		requireLogged(t, "proxyOnContextCreate", host.GetDebugLogs())
+		requireLogged(t, "proxyOnConfigure", host.GetDebugLogs())
+		requireLogged(t, "proxyOnContextCreate", host.GetDebugLogs())
+		requireLogged(t, "proxyOnRequestHeaders", host.GetDebugLogs())
+		requireLogged(t, "proxyOnRequestBody", host.GetDebugLogs())
+		requireLogged(t, "proxyOnRequestTrailers", host.GetDebugLogs())
+		requireLogged(t, "proxyOnResponseHeaders", host.GetDebugLogs())
+		requireLogged(t, "proxyOnResponseBody", host.GetDebugLogs())
+		requireLogged(t, "proxyOnResponseTrailers", host.GetDebugLogs())
+		requireLogged(t, "proxyOnLog", host.GetDebugLogs())
+		requireLogged(t, "proxyOnDelete", host.GetDebugLogs())
+	})
+
+	t.Run("tcp", func(t *testing.T) {
+		host, reset := NewHostEmulator(NewEmulatorOption().WithVMContext(&noopPlugin{tcp: true}))
+		defer reset()
+
+		require.Equal(t, types.OnPluginStartStatusOK, host.StartPlugin())
+		id, action := host.InitializeConnection()
+		require.Equal(t, types.ActionContinue, action)
+
+		require.Equal(t, types.ActionContinue, host.CallOnDownstreamData(id, nil))
+		require.Equal(t, types.ActionContinue, host.CallOnUpstreamData(id, nil))
+		host.CompleteConnection(id)
+
+		requireLogged(t, "proxyOnContextCreate", host.GetDebugLogs())
+		requireLogged(t, "proxyOnConfigure", host.GetDebugLogs())
+		requireLogged(t, "proxyOnContextCreate", host.GetDebugLogs())
+		requireLogged(t, "proxyOnNewConnection", host.GetDebugLogs())
+		requireLogged(t, "proxyOnDownstreamData", host.GetDebugLogs())
+		requireLogged(t, "proxyOnUpstreamData", host.GetDebugLogs())
+		requireLogged(t, "proxyOnLog", host.GetDebugLogs())
+		requireLogged(t, "proxyOnDelete", host.GetDebugLogs())
+	})
+}
+
+func requireLogged(t *testing.T, msg string, logs []string) {
+	t.Helper()
+	re := regexp.MustCompile(fmt.Sprintf(`%s took \d+`, msg))
+	for _, l := range logs {
+		if re.MatchString(l) {
+			return
+		}
+	}
+	require.Failf(t, "expected log", "expected log %s, got %v", msg, logs)
+}

--- a/proxywasm/types/context.go
+++ b/proxywasm/types/context.go
@@ -17,19 +17,19 @@ package types
 // There are four types of these intefaces which you are supposed to implement in order to extend your network proxies.
 // They are VMContext, PluginContext, TcpContext and HttpContext, and their relationship can be described as the following diagram:
 //
-//                          Wasm Virtual Machine(VM)
-//                     (corresponds to VM configuration)
-//  ┌────────────────────────────────────────────────────────────────────────────┐
-//  │                                                      TcpContext            │
-//  │                                                  ╱ (Each Tcp stream)       │
-//  │                                                 ╱                          │
-//  │                      1: N                      ╱ 1: N                      │
-//  │       VMContext  ──────────  PluginContext                                 │
-//  │  (VM configuration)     (Plugin configuration) ╲ 1: N                      │
-//  │                                                 ╲                          │
-//  │                                                  ╲   HttpContext           │
-//  │                                                   (Each Http stream)       │
-//  └────────────────────────────────────────────────────────────────────────────┘
+//	                        Wasm Virtual Machine(VM)
+//	                   (corresponds to VM configuration)
+//	┌────────────────────────────────────────────────────────────────────────────┐
+//	│                                                      TcpContext            │
+//	│                                                  ╱ (Each Tcp stream)       │
+//	│                                                 ╱                          │
+//	│                      1: N                      ╱ 1: N                      │
+//	│       VMContext  ──────────  PluginContext                                 │
+//	│  (VM configuration)     (Plugin configuration) ╲ 1: N                      │
+//	│                                                 ╲                          │
+//	│                                                  ╲   HttpContext           │
+//	│                                                   (Each Http stream)       │
+//	└────────────────────────────────────────────────────────────────────────────┘
 //
 // To summarize,
 //
@@ -48,7 +48,6 @@ package types
 // 5) TcpContext is responsible for handling individual Tcp stream events.
 //
 // 6) HttpContext is responsible for handling individual Http stream events.
-//
 //
 // VMContext corresponds to a Wasm VM machine and its configuration.
 // It's the entrypoint for extending the network proxy.


### PR DESCRIPTION
Fixes #326 

There's some reformatting and lint fixes because of using Go 1.19 to develop, let me know if I should revert them for this PR