### PR TITLE
test framework: Implement ProxyGetProperty and ProxySetProperty

### DIFF
--- a/examples/properties/README.md
+++ b/examples/properties/README.md
@@ -1,0 +1,101 @@
+## properties
+
+this example prevalidates the authentication header via the usage of properties fetched from the proxy (i.e. Envoy metadata here).
+
+### message on clients
+```
+curl localhost:18000/one -v
+*   Trying 127.0.0.1:18000...
+* Connected to localhost (127.0.0.1) port 18000 (#0)
+> GET /one HTTP/1.1
+> Host: localhost:18000
+> User-Agent: curl/7.82.0
+> Accept: */*
+> 
+< HTTP/1.1 401 Unauthorized
+< date: Mon, 31 Oct 2022 00:53:01 GMT
+< server: envoy
+< content-length: 0
+< 
+
+curl localhost:18000/one -v -H 'cookie: value'
+*   Trying 127.0.0.1:18000...
+* Connected to localhost (127.0.0.1) port 18000 (#0)
+> GET /one HTTP/1.1
+> Host: localhost:18000
+> User-Agent: curl/7.82.0
+> Accept: */*
+> cookie: value
+> 
+< HTTP/1.1 200 OK
+< content-length: 13
+< content-type: text/plain
+< date: Mon, 31 Oct 2022 00:54:59 GMT
+< server: envoy
+< x-envoy-upstream-service-time: 0
+< 
+example body
+
+curl localhost:18000/two -v
+*   Trying 127.0.0.1:18000...
+* Connected to localhost (127.0.0.1) port 18000 (#0)
+> GET /two HTTP/1.1
+> Host: localhost:18000
+> User-Agent: curl/7.82.0
+> Accept: */*
+> 
+< HTTP/1.1 401 Unauthorized
+< date: Mon, 31 Oct 2022 00:53:30 GMT
+< server: envoy
+< content-length: 0
+< 
+
+curl localhost:18000/two -v -H 'authorization: token'
+*   Trying 127.0.0.1:18000...
+* Connected to localhost (127.0.0.1) port 18000 (#0)
+> GET /two HTTP/1.1
+> Host: localhost:18000
+> User-Agent: curl/7.82.0
+> Accept: */*
+> authorization: token
+> 
+< HTTP/1.1 200 OK
+< content-length: 13
+< content-type: text/plain
+< date: Mon, 31 Oct 2022 00:53:52 GMT
+< server: envoy
+< x-envoy-upstream-service-time: 0
+< 
+example body
+
+curl localhost:18000/three -v
+*   Trying 127.0.0.1:18000...
+* Connected to localhost (127.0.0.1) port 18000 (#0)
+> GET /three HTTP/1.1
+> Host: localhost:18000
+> User-Agent: curl/7.82.0
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+< content-length: 13
+< content-type: text/plain
+< date: Mon, 31 Oct 2022 00:55:27 GMT
+< server: envoy
+< x-envoy-upstream-service-time: 0
+< 
+example body
+```
+
+### message on Envoy
+```
+wasm log: auth header is "cookie"
+wasm log: 2 finished
+wasm log: auth header is "cookie"
+wasm log: 3 finished
+wasm log: auth header is "authorization"
+wasm log: 2 finished
+wasm log: auth header is "authorization"
+wasm log: 3 finished
+wasm log: no auth header for route
+wasm log: 4 finished
+```

--- a/examples/properties/envoy.yaml
+++ b/examples/properties/envoy.yaml
@@ -1,0 +1,108 @@
+static_resources:
+  listeners:
+    - name: main
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 18000
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/one"
+                          route:
+                            cluster: web_service
+                          metadata:
+                            filter_metadata:
+                              envoy.filters.http.wasm:
+                                auth: "cookie"
+                        - match:
+                            prefix: "/two"
+                          route:
+                            cluster: web_service
+                          metadata:
+                            filter_metadata:
+                              envoy.filters.http.wasm:
+                                auth: "authorization"
+                        - match:
+                            prefix: "/three"
+                          route:
+                            cluster: web_service
+                http_filters:
+                  - name: envoy.filters.http.wasm
+                    typed_config:
+                      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+                      type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+                      value:
+                        config:
+                          vm_config:
+                            runtime: "envoy.wasm.runtime.v8"
+                            code:
+                              local:
+                                filename: "./examples/properties/main.wasm"
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+    - name: staticreply
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 8099
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          direct_response:
+                            status: 200
+                            body:
+                              inline_string: "example body\n"
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+    - name: web_service
+      connect_timeout: 0.25s
+      type: STATIC
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: mock_service
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8099
+
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/properties/go.mod
+++ b/examples/properties/go.mod
@@ -12,6 +12,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/tetratelabs/wazero v1.0.0-beta.2 // indirect
+	github.com/tetratelabs/wazero v1.0.0-pre.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/properties/go.mod
+++ b/examples/properties/go.mod
@@ -1,0 +1,17 @@
+module github.com/tetratelabs/proxy-wasm-go-sdk/examples/properties
+
+go 1.18
+
+replace github.com/tetratelabs/proxy-wasm-go-sdk => ../..
+
+require (
+	github.com/stretchr/testify v1.8.0
+	github.com/tetratelabs/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wazero v1.0.0-beta.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/examples/properties/go.sum
+++ b/examples/properties/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/tetratelabs/wazero v1.0.0-beta.2 h1:Qa1R1oizAYHcmy8PljgINdXUZ/nRQkxUBbYfGSb4IBE=
+github.com/tetratelabs/wazero v1.0.0-beta.2/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/properties/go.sum
+++ b/examples/properties/go.sum
@@ -8,8 +8,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/tetratelabs/wazero v1.0.0-beta.2 h1:Qa1R1oizAYHcmy8PljgINdXUZ/nRQkxUBbYfGSb4IBE=
-github.com/tetratelabs/wazero v1.0.0-beta.2/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+github.com/tetratelabs/wazero v1.0.0-pre.2 h1:sHYi8DKUL7s7c4sKz6lw0pNqky5EogYK0Iq4pSIsDog=
+github.com/tetratelabs/wazero v1.0.0-pre.2/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/properties/main.go
+++ b/examples/properties/main.go
@@ -1,0 +1,99 @@
+// Copyright 2020-2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func main() {
+	proxywasm.SetVMContext(&vmContext{})
+}
+
+type vmContext struct {
+	// Embed the default VM context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultVMContext
+}
+
+// Override types.DefaultVMContext.
+func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &pluginContext{}
+}
+
+type pluginContext struct {
+	// Embed the default plugin context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultPluginContext
+}
+
+// Override types.DefaultPluginContext.
+func (*pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
+	return &properties{contextID: contextID}
+}
+
+type properties struct {
+	// Embed the default http context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultHttpContext
+	contextID uint32
+}
+
+var propertyPrefix = []string{
+	"route_metadata",
+	"filter_metadata",
+	"envoy.filters.http.wasm",
+}
+
+// Override types.DefaultHttpContext.
+func (ctx *properties) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	auth, err := proxywasm.GetProperty(append(propertyPrefix, "auth"))
+	if err != nil {
+		if err == types.ErrorStatusNotFound {
+			proxywasm.LogInfo("no auth header for route")
+			return types.ActionContinue
+		}
+		proxywasm.LogCriticalf("failed to read properties: %v", err)
+	}
+	proxywasm.LogInfof("auth header is \"%s\"", auth)
+
+	hs, err := proxywasm.GetHttpRequestHeaders()
+	if err != nil {
+		proxywasm.LogCriticalf("failed to get request headers: %v", err)
+	}
+
+	// Verify authentication header exists
+	authHeader := false
+	for _, h := range hs {
+		if h[0] == string(auth) {
+			authHeader = true
+			break
+		}
+	}
+
+	// Reject requests without authentication header
+	if !authHeader {
+		proxywasm.SendHttpResponse(401, nil, nil, 16)
+		return types.ActionPause
+	}
+
+	return types.ActionContinue
+}
+
+// Override types.DefaultHttpContext.
+func (ctx *properties) OnHttpStreamDone() {
+	proxywasm.LogInfof("%d finished", ctx.contextID)
+}

--- a/examples/properties/main_test.go
+++ b/examples/properties/main_test.go
@@ -1,0 +1,110 @@
+// The framework emulates the expected behavior of Envoyproxy, and you can test your extensions without running Envoy and with
+// the standard Go CLI. To run tests, simply run
+// go test ./...
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func TestProperties_OnHttpRequestHeaders(t *testing.T) {
+	vmTest(t, func(t *testing.T, vm types.VMContext) {
+		opt := proxytest.NewEmulatorOption().WithVMContext(vm)
+		host, reset := proxytest.NewHostEmulator(opt)
+		defer reset()
+
+		t.Run("route is unauthenticated", func(t *testing.T) {
+			// Initialize http context.
+			id := host.InitializeHttpContext()
+
+			// Call OnRequestHeaders.
+			action := host.CallOnRequestHeaders(id, nil, false)
+			require.Equal(t, types.ActionContinue, action)
+
+			// Call OnHttpStreamDone.
+			host.CompleteHttpContext(id)
+
+			// Check Envoy logs.
+			logs := host.GetInfoLogs()
+			require.Contains(t, logs, fmt.Sprintf("no auth header for route"))
+			require.Contains(t, logs, fmt.Sprintf("%d finished", id))
+		})
+
+		// Set property
+		path := "auth"
+		data := "cookie"
+		host.SetProperty(append(propertyPrefix, path), []byte(data))
+
+		// Get property
+		actualData, _ := host.GetProperty(append(propertyPrefix, path))
+		require.Equal(t, string(actualData), data)
+
+		t.Run("user is authenticated", func(t *testing.T) {
+			// Initialize http context.
+			id := host.InitializeHttpContext()
+
+			// Call OnRequestHeaders.
+			action := host.CallOnRequestHeaders(id, [][2]string{
+				{"cookie", "value"},
+			}, false)
+			require.Equal(t, types.ActionContinue, action)
+
+			// Call OnHttpStreamDone.
+			host.CompleteHttpContext(id)
+
+			// Check Envoy logs.
+			logs := host.GetInfoLogs()
+			require.Contains(t, logs, fmt.Sprintf("auth header is \"%s\"", data))
+			require.Contains(t, logs, fmt.Sprintf("%d finished", id))
+		})
+
+		t.Run("user is unauthenticated", func(t *testing.T) {
+			// Initialize http context.
+			id := host.InitializeHttpContext()
+
+			// Call OnRequestHeaders.
+			action := host.CallOnRequestHeaders(id, nil, false)
+			require.Equal(t, types.ActionPause, action)
+
+			// Call OnHttpStreamDone.
+			host.CompleteHttpContext(id)
+
+			// Check the local response.
+			localResponse := host.GetSentLocalResponse(id)
+			require.NotNil(t, localResponse)
+			require.Equal(t, uint32(401), localResponse.StatusCode)
+			require.Nil(t, localResponse.Data)
+		})
+
+	})
+}
+
+// vmTest executes f twice, once with a types.VMContext that executes plugin code directly
+// in the host, and again by executing the plugin code within the compiled main.wasm binary.
+// Execution with main.wasm will be skipped if the file cannot be found.
+func vmTest(t *testing.T, f func(*testing.T, types.VMContext)) {
+	t.Helper()
+
+	t.Run("go", func(t *testing.T) {
+		f(t, &vmContext{})
+	})
+
+	t.Run("wasm", func(t *testing.T) {
+		wasm, err := os.ReadFile("main.wasm")
+		if err != nil {
+			t.Skip("wasm not found")
+		}
+		v, err := proxytest.NewWasmVMContext(wasm)
+		require.NoError(t, err)
+		defer v.Close()
+		f(t, v)
+	})
+}

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -537,7 +537,7 @@ func SetSharedData(key string, data []byte, cas uint32) error {
 // Available path and properties depend on the host implementation.
 // For Envoy, please refer to https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
 //
-// Note: if the target propety is map-type, use GetPropetyMap instead. This GetProperty returns
+// Note: if the target property is map-type, use GetPropertyMap instead. This GetProperty returns
 // raw un-serialized bytes for such properties. For example, if you have the metadata as
 //
 //	clusters:
@@ -551,11 +551,11 @@ func SetSharedData(key string, data []byte, cas uint32) error {
 //	         k2: v2
 //
 // Then,
-//   - use GetPropetyMap for {"cluster_metadata", "filter_metadata", "foo", "my_map"}.
-//   - use GetProperty   for {"cluster_metadata", "filter_metadata", "foo", "my_value"}.
+//   - use GetPropertyMap for {"cluster_metadata", "filter_metadata", "foo", "my_map"}.
+//   - use GetProperty    for {"cluster_metadata", "filter_metadata", "foo", "my_value"}.
 //
 // Note: you cannot get the raw bytes of protobuf. For example, accessing {"cluster_metadata", "filter_data", "foo"}) doesn't
-// returns the protobuf bytes, but instead this returns the serialized map of "foo". Therefore, we recommend to access individual
+// return the protobuf bytes, but instead this returns the serialized map of "foo". Therefore, we recommend to access individual
 // "leaf" fields (not the middle or top field of metadata) to avoid the need to figure out the (host-dependent) encoding of properties.
 func GetProperty(path []string) ([]byte, error) {
 	if len(path) == 0 {

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -260,23 +260,23 @@ func (h *hostEmulator) ProxySetEffectiveContext(contextID uint32) internal.Statu
 }
 
 // impl internal.ProxyWasmHost
-func (h *hostEmulator) ProxySetProperty(namePtr *byte, nameSize int, valuePtr *byte, valueSize int) internal.Status {
-	name := internal.RawBytePtrToString(namePtr, nameSize)
-	value := internal.RawBytePtrToByteSlice(valuePtr, valueSize)
-	h.properties[name] = value
+func (h *hostEmulator) ProxySetProperty(pathPtr *byte, pathSize int, dataPtr *byte, dataSize int) internal.Status {
+	path := internal.RawBytePtrToString(pathPtr, pathSize)
+	data := internal.RawBytePtrToByteSlice(dataPtr, dataSize)
+	h.properties[path] = data
 	return internal.StatusOK
 }
 
 // impl internal.ProxyWasmHost
-func (h *hostEmulator) ProxyGetProperty(namePtr *byte, nameSize int, valuePtrPtr **byte, valueSizePtr *int) internal.Status {
-	name := internal.RawBytePtrToString(namePtr, nameSize)
-	if _, ok := h.properties[name]; !ok {
+func (h *hostEmulator) ProxyGetProperty(pathPtr *byte, pathSize int, dataPtrPtr **byte, dataSizePtr *int) internal.Status {
+	path := internal.RawBytePtrToString(pathPtr, pathSize)
+	if _, ok := h.properties[path]; !ok {
 		return internal.StatusNotFound
 	}
-	value := h.properties[name]
-	*valuePtrPtr = &value[0]
-	valueSize := len(value)
-	*valueSizePtr = valueSize
+	data := h.properties[path]
+	*dataPtrPtr = &data[0]
+	dataSize := len(data)
+	*dataSizePtr = dataSize
 	return internal.StatusOK
 }
 

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -140,7 +140,7 @@ type hostEmulator struct {
 	*httpHostEmulator
 
 	effectiveContextID uint32
-	properties         map[string]string
+	properties         map[string][]byte
 }
 
 // NewHostEmulator returns a new HostEmulator that can be used to test a plugin. Plugin tests will
@@ -155,7 +155,7 @@ func NewHostEmulator(opt *EmulatorOption) (host HostEmulator, reset func()) {
 		network,
 		http,
 		0,
-		make(map[string]string),
+		make(map[string][]byte),
 	}
 
 	release := internal.RegisterMockWasmHost(emulator)
@@ -262,7 +262,7 @@ func (h *hostEmulator) ProxySetEffectiveContext(contextID uint32) internal.Statu
 // impl internal.ProxyWasmHost
 func (h *hostEmulator) ProxySetProperty(namePtr *byte, nameSize int, valuePtr *byte, valueSize int) internal.Status {
 	name := internal.RawBytePtrToString(namePtr, nameSize)
-	value := internal.RawBytePtrToString(valuePtr, valueSize)
+	value := internal.RawBytePtrToByteSlice(valuePtr, valueSize)
 	h.properties[name] = value
 	return internal.StatusOK
 }
@@ -274,7 +274,7 @@ func (h *hostEmulator) ProxyGetProperty(namePtr *byte, nameSize int, valuePtrPtr
 		return internal.StatusNotFound
 	}
 	value := h.properties[name]
-	*valuePtrPtr = internal.StringBytePtr(value)
+	*valuePtrPtr = &value[0]
 	valueSize := len(value)
 	*valueSizePtr = valueSize
 	return internal.StatusOK

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"unsafe"
 
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/internal"
@@ -274,8 +273,8 @@ func (h *hostEmulator) ProxyGetProperty(namePtr *byte, nameSize int, valuePtrPtr
 	if _, ok := h.properties[name]; !ok {
 		return internal.StatusNotFound
 	}
-	value := []byte(h.properties[name])
-	*valuePtrPtr = (*byte)(unsafe.Pointer(&value))
+	value := h.properties[name]
+	*valuePtrPtr = internal.StringBytePtr(value)
 	valueSize := len(value)
 	*valueSizePtr = valueSize
 	return internal.StatusOK

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -126,6 +126,10 @@ type HostEmulator interface {
 	// host. This contains the arguments passed to proxywasm.SendHttpResponse in the plugin. If
 	// proxywasm.SendHttpResponse hasn't been invoked by the plugin, this will return nil.
 	GetSentLocalResponse(contextID uint32) *LocalHttpResponse
+	// GetProperty returns property data from the host, for a given path.
+	GetProperty(path []string) ([]byte, error)
+	// SetProperty sets property data on the host, for a given path.
+	SetProperty(path []string, data []byte) error
 }
 
 const (


### PR DESCRIPTION
This pull request addresses [Issue #250](https://github.com/tetratelabs/proxy-wasm-go-sdk/issues/250). It implements the `ProxyGetProperty` and `ProxySetProperty` methods in `proxytest` and stores properties in a map.

Do you have any concerns about potential race conditions for the map within the context of `proxytest`? Thank you.