### PR TITLE
Adds headers based on argument for "http_headers" example

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -145,8 +145,10 @@ func Test_http_headers(t *testing.T) {
 			return false
 		}
 		defer res.Body.Close()
+		require.Equal(t, res.Header.Get("x-wasm-header"), "demo-wasm")
+		require.Equal(t, res.Header.Get("x-proxy-wasm-go-sdk-example"), "http_headers")
 		return checkMessage(stdErr.String(), []string{
-			key, value, "server: envoy",
+			key, value, "server: envoy", "x-wasm-header", "x-proxy-wasm-go-sdk-example",
 		}, nil)
 	}, 5*time.Second, time.Millisecond, stdErr.String())
 }

--- a/examples/http_headers/README.md
+++ b/examples/http_headers/README.md
@@ -1,6 +1,15 @@
 ## http_headers
 
-this example handles http request/response headers events and log all headers.
+This example handles http request/response headers events and log all headers.
+
+In case there is information in the argument it will add the header to the response: 
+
+```yaml
+header: custom-header
+value: custom-value
+```
+
+Also, it adds a hardcoded header "x-proxy-wasm-go-sdk-example" with value "http_headers". 
 
 ```
 wasm log: request header --> :authority: localhost:18000
@@ -16,5 +25,7 @@ wasm log: response header <-- content-type: text/plain
 wasm log: response header <-- date: Thu, 01 Oct 2020 09:10:09 GMT
 wasm log: response header <-- server: envoy
 wasm log: response header <-- x-envoy-upstream-service-time: 0
+wasm log: response header --> x-proxy-wasm-go-sdk-example: http_headers
+wasm log: response header --> custom-header: custom-value
 wasm log: 2 finished
 ```

--- a/examples/http_headers/README.md
+++ b/examples/http_headers/README.md
@@ -32,6 +32,6 @@ wasm log: response header <-- date: Thu, 01 Oct 2020 09:10:09 GMT
 wasm log: response header <-- server: envoy
 wasm log: response header <-- x-envoy-upstream-service-time: 0
 wasm log: response header --> x-proxy-wasm-go-sdk-example: http_headers
-wasm log: response header --> custom-header: custom-value
+wasm log: response header --> x-wasm-header: demo-wasm
 wasm log: 2 finished
 ```

--- a/examples/http_headers/README.md
+++ b/examples/http_headers/README.md
@@ -2,13 +2,9 @@
 
 This example handles http request/response headers events and log all headers.
 
-In case there is information in the argument it will add the header to the response: 
+In envoy.yaml, the custom header is given as the plugin configuration like the following:
 
-```yaml
-header: custom-header
-value: custom-value
-```
-
+and this adds the `x-wasm-header: demo-wasm` header to all the responses.
 Also, it adds a hardcoded header "x-proxy-wasm-go-sdk-example" with value "http_headers". 
 
 ```

--- a/examples/http_headers/README.md
+++ b/examples/http_headers/README.md
@@ -4,6 +4,16 @@ This example handles http request/response headers events and log all headers.
 
 In envoy.yaml, the custom header is given as the plugin configuration like the following:
 
+```yaml
+configuration:
+  "@type": type.googleapis.com/google.protobuf.StringValue
+  value: |
+    {
+      "header": "x-wasm-header",
+      "value": "demo-wasm"
+    }
+```
+
 and this adds the `x-wasm-header: demo-wasm` header to all the responses.
 Also, it adds a hardcoded header "x-proxy-wasm-go-sdk-example" with value "http_headers". 
 

--- a/examples/http_headers/envoy.yaml
+++ b/examples/http_headers/envoy.yaml
@@ -30,6 +30,13 @@ static_resources:
                       type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
                       value:
                         config:
+                          configuration:
+                            "@type": type.googleapis.com/google.protobuf.StringValue
+                            value: |
+                              {
+                                "header": "x-wasm-header"
+                                "value": "demo-wasm"
+                              }
                           vm_config:
                             runtime: "envoy.wasm.runtime.v8"
                             code:

--- a/examples/http_headers/envoy.yaml
+++ b/examples/http_headers/envoy.yaml
@@ -34,7 +34,7 @@ static_resources:
                             "@type": type.googleapis.com/google.protobuf.StringValue
                             value: |
                               {
-                                "header": "x-wasm-header"
+                                "header": "x-wasm-header",
                                 "value": "demo-wasm"
                               }
                           vm_config:

--- a/examples/http_headers/go.mod
+++ b/examples/http_headers/go.mod
@@ -7,11 +7,14 @@ replace github.com/tetratelabs/proxy-wasm-go-sdk => ../..
 require (
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/tidwall/gjson v1.14.3
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/tetratelabs/wazero v1.0.0-pre.3 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/http_headers/go.sum
+++ b/examples/http_headers/go.sum
@@ -10,6 +10,12 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
 github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
+github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/http_headers/main.go
+++ b/examples/http_headers/main.go
@@ -15,8 +15,11 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/tidwall/gjson"
 )
 
 func main() {
@@ -30,7 +33,7 @@ type vmContext struct {
 }
 
 // Override types.DefaultVMContext.
-func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+func (*vmContext) NewPluginContext(_ uint32) types.PluginContext {
 	return &pluginContext{}
 }
 
@@ -38,22 +41,57 @@ type pluginContext struct {
 	// Embed the default plugin context here,
 	// so that we don't need to reimplement all the methods.
 	types.DefaultPluginContext
+
+	headerName  string
+	headerValue string
 }
 
 // Override types.DefaultPluginContext.
-func (*pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
-	return &httpHeaders{contextID: contextID}
+func (p *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
+	return &httpHeaders{
+		contextID:   contextID,
+		headerName:  p.headerName,
+		headerValue: p.headerValue,
+	}
+}
+
+func (p *pluginContext) OnPluginStart(_ int) types.OnPluginStartStatus {
+	proxywasm.LogDebug("loading plugin config")
+	data, err := proxywasm.GetPluginConfiguration()
+	if err != nil {
+		proxywasm.LogCriticalf("error reading plugin configuration: %v", err)
+		return types.OnPluginStartStatusFailed
+	}
+
+	if !gjson.Valid(string(data)) {
+		proxywasm.LogCritical(`invalid configuration format; expected {"header": "<header name>", "value": "<header value>"}`)
+		return types.OnPluginStartStatusFailed
+	}
+
+	p.headerName = strings.TrimSpace(gjson.Get(string(data), "header").Str)
+	p.headerValue = strings.TrimSpace(gjson.Get(string(data), "value").Str)
+
+	if p.headerName == "" || p.headerValue == "" {
+		proxywasm.LogCritical(`invalid configuration format; expected {"header": "<header name>", "value": "<header value>"}`)
+		return types.OnPluginStartStatusFailed
+	}
+
+	proxywasm.LogInfof("header from config: %s = %s", p.headerName, p.headerValue)
+
+	return types.OnPluginStartStatusOK
 }
 
 type httpHeaders struct {
 	// Embed the default http context here,
 	// so that we don't need to reimplement all the methods.
 	types.DefaultHttpContext
-	contextID uint32
+	contextID   uint32
+	headerName  string
+	headerValue string
 }
 
 // Override types.DefaultHttpContext.
-func (ctx *httpHeaders) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+func (ctx *httpHeaders) OnHttpRequestHeaders(_ int, _ bool) types.Action {
 	err := proxywasm.ReplaceHttpRequestHeader("test", "best")
 	if err != nil {
 		proxywasm.LogCritical("failed to set request header: test")
@@ -71,7 +109,22 @@ func (ctx *httpHeaders) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 }
 
 // Override types.DefaultHttpContext.
-func (ctx *httpHeaders) OnHttpResponseHeaders(numHeaders int, endOfStream bool) types.Action {
+func (ctx *httpHeaders) OnHttpResponseHeaders(_ int, _ bool) types.Action {
+	proxywasm.LogInfof("adding header: %s=%s", ctx.headerName, ctx.headerValue)
+
+	// Add a hardcoded header
+	if err := proxywasm.AddHttpResponseHeader("x-proxy-wasm-go-sdk-example", "http_headers"); err != nil {
+		proxywasm.LogCriticalf("failed to set response constant header: %v", err)
+	}
+
+	// Add the header passed by arguments
+	if ctx.headerName != "" {
+		if err := proxywasm.AddHttpResponseHeader(ctx.headerName, ctx.headerValue); err != nil {
+			proxywasm.LogCriticalf("failed to set response headers: %v", err)
+		}
+	}
+
+	// Get and log the headers
 	hs, err := proxywasm.GetHttpResponseHeaders()
 	if err != nil {
 		proxywasm.LogCriticalf("failed to get response headers: %v", err)

--- a/examples/http_headers/main.go
+++ b/examples/http_headers/main.go
@@ -43,7 +43,7 @@ type pluginContext struct {
 	// so that we don't need to reimplement all the methods.
 	types.DefaultPluginContext
 
-	// headerName and headerValue are the header to be added to response. They are configured via 
+	// headerName and headerValue are the header to be added to response. They are configured via
 	// plugin configuration during OnPluginStart.
 	headerName  string
 	headerValue string

--- a/examples/http_headers/main.go
+++ b/examples/http_headers/main.go
@@ -17,9 +17,10 @@ package main
 import (
 	"strings"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
-	"github.com/tidwall/gjson"
 )
 
 func main() {
@@ -58,6 +59,10 @@ func (p *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
 func (p *pluginContext) OnPluginStart(_ int) types.OnPluginStartStatus {
 	proxywasm.LogDebug("loading plugin config")
 	data, err := proxywasm.GetPluginConfiguration()
+	if data == nil {
+		return types.OnPluginStartStatusOK
+	}
+
 	if err != nil {
 		proxywasm.LogCriticalf("error reading plugin configuration: %v", err)
 		return types.OnPluginStartStatusFailed

--- a/examples/http_headers/main.go
+++ b/examples/http_headers/main.go
@@ -43,7 +43,8 @@ type pluginContext struct {
 	// so that we don't need to reimplement all the methods.
 	types.DefaultPluginContext
 
-	// Header passed by argument. If not empty will be added to the response
+	// headerName and headerValue are the header to be added to response. They are configured via 
+	// plugin configuration during OnPluginStart.
 	headerName  string
 	headerValue string
 }

--- a/examples/http_headers/main.go
+++ b/examples/http_headers/main.go
@@ -34,7 +34,7 @@ type vmContext struct {
 }
 
 // Override types.DefaultVMContext.
-func (*vmContext) NewPluginContext(_ uint32) types.PluginContext {
+func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
 	return &pluginContext{}
 }
 
@@ -43,6 +43,7 @@ type pluginContext struct {
 	// so that we don't need to reimplement all the methods.
 	types.DefaultPluginContext
 
+	// Header passed by argument. If not empty will be added to the response
 	headerName  string
 	headerValue string
 }
@@ -56,7 +57,7 @@ func (p *pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
 	}
 }
 
-func (p *pluginContext) OnPluginStart(_ int) types.OnPluginStartStatus {
+func (p *pluginContext) OnPluginStart(pluginConfigurationSize int) types.OnPluginStartStatus {
 	proxywasm.LogDebug("loading plugin config")
 	data, err := proxywasm.GetPluginConfiguration()
 	if data == nil {
@@ -96,7 +97,7 @@ type httpHeaders struct {
 }
 
 // Override types.DefaultHttpContext.
-func (ctx *httpHeaders) OnHttpRequestHeaders(_ int, _ bool) types.Action {
+func (ctx *httpHeaders) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
 	err := proxywasm.ReplaceHttpRequestHeader("test", "best")
 	if err != nil {
 		proxywasm.LogCritical("failed to set request header: test")


### PR DESCRIPTION
In order to check on a basic `curl` command the execution of the wasm extension, the `http_headers` example now will add to the response a header based on the value of the argument and also a hardcoded header to check that is working even with an empty argument.