### PR TITLE
ci: upgrade TinyGo 0.26, drop EOL versions of Envoy/Istio

### DIFF
--- a/.github/workflows/push-wasm-images.yaml
+++ b/.github/workflows/push-wasm-images.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 env:
-  TINYGO_VERSION: 0.25.0
+  TINYGO_VERSION: 0.26.0
 
 jobs:
   build-and-push-wasm-images:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  TINYGO_VERSION: 0.25.0
+  TINYGO_VERSION: 0.26.0
 
 jobs:
   style:
@@ -51,15 +51,10 @@ jobs:
       matrix:
         envoy-image: [
           "envoyproxy/envoy-dev:latest",
-          "envoyproxy/envoy:v1.19-latest",
-          "envoyproxy/envoy:v1.20-latest",
           "envoyproxy/envoy:v1.21-latest",
           "envoyproxy/envoy:v1.22-latest",
           "envoyproxy/envoy:v1.23-latest",
           "envoyproxy/envoy:v1.24-latest",
-          "istio/proxyv2:1.11.7",
-          "istio/proxyv2:1.12.4",
-          "istio/proxyv2:1.13.1",
           "istio/proxyv2:1.14.0",
           "istio/proxyv2:1.15.0",
           "istio/proxyv2:1.16.0",


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>