### PR TITLE
Update log descriptions

### DIFF
--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -623,7 +623,7 @@ func CallForeignFunction(funcName string, param []byte) (ret []byte, err error) 
 	}
 }
 
-// LogTracef emits a message as a log with Trace log level.
+// LogTrace emits a message as a log with Trace log level.
 func LogTrace(msg string) {
 	internal.ProxyLog(internal.LogLevelTrace, internal.StringBytePtr(msg), len(msg))
 }
@@ -634,7 +634,7 @@ func LogTracef(format string, args ...interface{}) {
 	internal.ProxyLog(internal.LogLevelTrace, internal.StringBytePtr(msg), len(msg))
 }
 
-// LogTracef emits a message as a log with Debug log level.
+// LogDebug emits a message as a log with Debug log level.
 func LogDebug(msg string) {
 	internal.ProxyLog(internal.LogLevelDebug, internal.StringBytePtr(msg), len(msg))
 }
@@ -645,7 +645,7 @@ func LogDebugf(format string, args ...interface{}) {
 	internal.ProxyLog(internal.LogLevelDebug, internal.StringBytePtr(msg), len(msg))
 }
 
-// LogTracef emits a message as a log with Info log level.
+// LogInfo emits a message as a log with Info log level.
 func LogInfo(msg string) {
 	internal.ProxyLog(internal.LogLevelInfo, internal.StringBytePtr(msg), len(msg))
 }
@@ -656,7 +656,7 @@ func LogInfof(format string, args ...interface{}) {
 	internal.ProxyLog(internal.LogLevelInfo, internal.StringBytePtr(msg), len(msg))
 }
 
-// LogTracef emits a message as a log with Warn log level.
+// LogWarn emits a message as a log with Warn log level.
 func LogWarn(msg string) {
 	internal.ProxyLog(internal.LogLevelWarn, internal.StringBytePtr(msg), len(msg))
 }
@@ -667,7 +667,7 @@ func LogWarnf(format string, args ...interface{}) {
 	internal.ProxyLog(internal.LogLevelWarn, internal.StringBytePtr(msg), len(msg))
 }
 
-// LogTracef emits a message as a log with Error log level.
+// LogError emits a message as a log with Error log level.
 func LogError(msg string) {
 	internal.ProxyLog(internal.LogLevelError, internal.StringBytePtr(msg), len(msg))
 }
@@ -678,7 +678,7 @@ func LogErrorf(format string, args ...interface{}) {
 	internal.ProxyLog(internal.LogLevelError, internal.StringBytePtr(msg), len(msg))
 }
 
-// LogTracef emits a message as a log with Critical log level.
+// LogCritical emits a message as a log with Critical log level.
 func LogCritical(msg string) {
 	internal.ProxyLog(internal.LogLevelCritical, internal.StringBytePtr(msg), len(msg))
 }

--- a/proxywasm/hostcall.go
+++ b/proxywasm/hostcall.go
@@ -629,6 +629,11 @@ func LogTrace(msg string) {
 }
 
 // LogTracef formats according to a format specifier and emits as a log with Trace log level.
+//
+// Note that not all combinations of format and args are supported by tinygo.
+// For example, %v with a map will cause a panic. See
+// https://tinygo.org/docs/reference/lang-support/stdlib/#fmt for more
+// information.
 func LogTracef(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	internal.ProxyLog(internal.LogLevelTrace, internal.StringBytePtr(msg), len(msg))
@@ -640,6 +645,11 @@ func LogDebug(msg string) {
 }
 
 // LogDebugf formats according to a format specifier and emits as a log with Debug log level.
+//
+// Note that not all combinations of format and args are supported by tinygo.
+// For example, %v with a map will cause a panic. See
+// https://tinygo.org/docs/reference/lang-support/stdlib/#fmt for more
+// information.
 func LogDebugf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	internal.ProxyLog(internal.LogLevelDebug, internal.StringBytePtr(msg), len(msg))
@@ -651,6 +661,11 @@ func LogInfo(msg string) {
 }
 
 // LogInfof formats according to a format specifier and emits as a log with Info log level.
+//
+// Note that not all combinations of format and args are supported by tinygo.
+// For example, %v with a map will cause a panic. See
+// https://tinygo.org/docs/reference/lang-support/stdlib/#fmt for more
+// information.
 func LogInfof(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	internal.ProxyLog(internal.LogLevelInfo, internal.StringBytePtr(msg), len(msg))
@@ -662,6 +677,11 @@ func LogWarn(msg string) {
 }
 
 // LogWarnf formats according to a format specifier and emits as a log with Warn log level.
+//
+// Note that not all combinations of format and args are supported by tinygo.
+// For example, %v with a map will cause a panic. See
+// https://tinygo.org/docs/reference/lang-support/stdlib/#fmt for more
+// information.
 func LogWarnf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	internal.ProxyLog(internal.LogLevelWarn, internal.StringBytePtr(msg), len(msg))
@@ -673,6 +693,11 @@ func LogError(msg string) {
 }
 
 // LogErrorf formats according to a format specifier and emits as a log with Error log level.
+//
+// Note that not all combinations of format and args are supported by tinygo.
+// For example, %v with a map will cause a panic. See
+// https://tinygo.org/docs/reference/lang-support/stdlib/#fmt for more
+// information.
 func LogErrorf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	internal.ProxyLog(internal.LogLevelError, internal.StringBytePtr(msg), len(msg))
@@ -684,6 +709,11 @@ func LogCritical(msg string) {
 }
 
 // LogCriticalf formats according to a format specifier and emits as a log with Critical log level.
+//
+// Note that not all combinations of format and args are supported by tinygo.
+// For example, %v with a map will cause a panic. See
+// https://tinygo.org/docs/reference/lang-support/stdlib/#fmt for more
+// information.
 func LogCriticalf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	internal.ProxyLog(internal.LogLevelCritical, internal.StringBytePtr(msg), len(msg))


### PR DESCRIPTION
This PR addresses #350 by noting that not all log format verbs are supported within tinygo at the time of writing. Adding the caveats as doc comments felt like the best place for them, as most common editor configurations will display doc comments inline or as a hover when using these functions.

There were also a few typos that appeared to be copy/paste errors, so those were cleaned up as well.