### PR TITLE
Adds `properties` package

### DIFF
--- a/properties/connection.go
+++ b/properties/connection.go
@@ -1,0 +1,165 @@
+package properties
+
+import "github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+
+// This file hosts helper functions to retrieve connection-related properties as described in:
+// https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#connection-attributes
+
+var (
+	sourceAddress                  = []string{"source", "address"}
+	sourcePort                     = []string{"source", "port"}
+	destinationAddress             = []string{"destination", "address"}
+	destinationPort                = []string{"destination", "port"}
+	connectionID                   = []string{"connection", "id"}
+	connectionMtls                 = []string{"connection", "mtls"}
+	connectionRequestedServerName  = []string{"connection", "requested_server_name"}
+	connectionTlsVersion           = []string{"connection", "tls_version"}
+	connectionSubjectLocalCert     = []string{"connection", "subject_local_certificate"}
+	connectionSubjectPeerCert      = []string{"connection", "subject_peer_certificate"}
+	connectionDnsSanLocalCert      = []string{"connection", "dns_san_local_certificate"}
+	connectionDnsSanPeerCert       = []string{"connection", "dns_san_peer_certificate"}
+	connectionUriSanLocalCert      = []string{"connection", "uri_san_local_certificate"}
+	connectionUriSanPeerCert       = []string{"connection", "uri_san_peer_certificate"}
+	connectionSha256PeerCertDigest = []string{"connection", "sha256_peer_certificate_digest"}
+	connectionTerminationDetails   = []string{"connection", "termination_details"}
+)
+
+// GetDownstreamRemoteAddress returns the remote address of the downstream connection.
+func GetDownstreamRemoteAddress() (string, error) {
+	downstreamRemoteAddress, err := getPropertyString(sourceAddress)
+	if err != nil {
+		return "", err
+	}
+	return downstreamRemoteAddress, nil
+}
+
+// GetDownstreamRemotePort returns the remote port of the downstream connection.
+func GetDownstreamRemotePort() (uint64, error) {
+	downstreamRemotePort, err := getPropertyUint64(sourcePort)
+	if err != nil {
+		return 0, err
+	}
+	return downstreamRemotePort, nil
+}
+
+// GetDownstreamLocalAddress returns the local address of the downstream connection.
+func GetDownstreamLocalAddress() (string, error) {
+	downstreamLocalAddress, err := getPropertyString(destinationAddress)
+	if err != nil {
+		return "", err
+	}
+	return downstreamLocalAddress, nil
+}
+
+// GetDownstreamLocalPort returns the local port of the downstream connection.
+func GetDownstreamLocalPort() (uint64, error) {
+	downstreamLocalPort, err := getPropertyUint64(destinationPort)
+	if err != nil {
+		return 0, err
+	}
+	return downstreamLocalPort, nil
+}
+
+// GetDownstreamConnectionID returns the connection ID of the downstream connection.
+func GetDownstreamConnectionID() (uint64, error) {
+	downstreamConnectionId, err := getPropertyUint64(connectionID)
+	if err != nil {
+		return 0, err
+	}
+	return downstreamConnectionId, nil
+}
+
+// IsDownstreamConnectionTls returns true if the downstream connection is TLS.
+func IsDownstreamConnectionTls() (bool, error) {
+	downstreamConnectionTls, err := getPropertyBool(connectionMtls)
+	if err != nil {
+		return false, err
+	}
+	return downstreamConnectionTls, nil
+}
+
+// GetDownstreamRequestedServerName returns the requested server name of the downstream connection.
+func GetDownstreamRequestedServerName() (string, error) {
+	downstreamRequestedServerName, err := getPropertyString(connectionRequestedServerName)
+	if err != nil {
+		return "", err
+	}
+	return downstreamRequestedServerName, nil
+}
+
+// GetDownstreamTlsVersion returns the TLS version of the downstream connection.
+func GetDownstreamTlsVersion() (string, error) {
+	downstreamTlsVersion, err := getPropertyString(connectionTlsVersion)
+	if err != nil {
+		return "", err
+	}
+	return downstreamTlsVersion, nil
+}
+
+// GetDownstreamSubjectLocalCertificate returns the subject field of the local certificate in the downstream TLS connection.
+func GetDownstreamSubjectLocalCertificate() (string, error) {
+	downstreamSubjectLocalCertificate, err := getPropertyString(connectionSubjectLocalCert)
+	if err != nil {
+		return "", err
+	}
+	return downstreamSubjectLocalCertificate, nil
+}
+
+// GetDownstreamSubjectPeerCertificate returns the subject field of the peer certificate in the downstream TLS connection.
+func GetDownstreamSubjectPeerCertificate() (string, error) {
+	downstreamSubjectPeerCertificate, err := getPropertyString(connectionSubjectPeerCert)
+	if err != nil {
+		return "", err
+	}
+	return downstreamSubjectPeerCertificate, nil
+}
+
+// GetDownstreamDnsSanLocalCertificate returns The first DNS entry in the SAN field of the local certificate in the downstream TLS connection.
+func GetDownstreamDnsSanLocalCertificate() (string, error) {
+	downstreamDnsSanLocalCertificate, err := getPropertyString(connectionDnsSanLocalCert)
+	if err != nil {
+		return "", err
+	}
+	return downstreamDnsSanLocalCertificate, nil
+}
+
+// GetDownstreamDnsSanPeerCertificate returns The first DNS entry in the SAN field of the peer certificate in the downstream TLS connection.
+func GetDownstreamDnsSanPeerCertificate() (string, error) {
+	downstreamDnsSanPeerCertificate, err := getPropertyString(connectionDnsSanPeerCert)
+	if err != nil {
+		return "", err
+	}
+	return downstreamDnsSanPeerCertificate, nil
+}
+
+// GetDownstreamUriSanLocalCertificate returns the first URI entry in the SAN field of the local certificate in the downstream TLS connection
+func GetDownstreamUriSanLocalCertificate() (string, error) {
+	downstreamUriSanLocalCertificate, err := getPropertyString(connectionUriSanLocalCert)
+	if err != nil {
+		return "", err
+	}
+	return downstreamUriSanLocalCertificate, nil
+}
+
+// GetDownstreamUriSanPeerCertificate returns The first URI entry in the SAN field of the peer certificate in the downstream TLS connection.
+func GetDownstreamUriSanPeerCertificate() (string, error) {
+	downstreamUriSanPeerCertificate, err := getPropertyString(connectionUriSanPeerCert)
+	if err != nil {
+		return "", err
+	}
+	return downstreamUriSanPeerCertificate, nil
+}
+
+// GetDownstreamSha256PeerCertificateDigest returns the SHA256 digest of a peer certificate digest of the downstream connection.
+func GetDownstreamSha256PeerCertificateDigest() ([]byte, error) {
+	return proxywasm.GetProperty(connectionSha256PeerCertDigest)
+}
+
+// GetDownstreamTerminationDetails returns the internal termination details of the connection (subject to change).
+func GetDownstreamTerminationDetails() (string, error) {
+	downstreamTerminationDetails, err := getPropertyString(connectionTerminationDetails)
+	if err != nil {
+		return "", err
+	}
+	return downstreamTerminationDetails, nil
+}

--- a/properties/connection_test.go
+++ b/properties/connection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
 )
 

--- a/properties/connection_test.go
+++ b/properties/connection_test.go
@@ -1,0 +1,179 @@
+package properties
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+)
+
+func TestGetDownstreamRemoteAddress(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(sourceAddress, []byte("1.2.3.4"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamRemoteAddress()
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3.4", result)
+}
+
+func TestGetDownstreamRemotePort(t *testing.T) {
+	var u64 [8]byte
+	binary.LittleEndian.PutUint64(u64[:], 1234)
+	opt := proxytest.NewEmulatorOption().WithProperty(sourcePort, u64[:])
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamRemotePort()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1234), result)
+}
+
+func TestGetDownstreamLocalAddress(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(destinationAddress, []byte("1.2.3.4"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamLocalAddress()
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3.4", result)
+}
+
+func TestGetDownstreamLocalPort(t *testing.T) {
+	var u64 [8]byte
+	binary.LittleEndian.PutUint64(u64[:], 1234)
+	opt := proxytest.NewEmulatorOption().WithProperty(destinationPort, u64[:])
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamLocalPort()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1234), result)
+}
+
+func TestGetDownstreamConnectionID(t *testing.T) {
+	var u64 [8]byte
+	binary.LittleEndian.PutUint64(u64[:], 1234)
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionID, u64[:])
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamConnectionID()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1234), result)
+}
+
+func TestIsDownstreamConnectionTls(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionMtls, []byte{1})
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := IsDownstreamConnectionTls()
+	require.NoError(t, err)
+	require.Equal(t, true, result)
+}
+
+func TestGetDownstreamRequestedServerName(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionRequestedServerName, []byte("example.com"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamRequestedServerName()
+	require.NoError(t, err)
+	require.Equal(t, "example.com", result)
+}
+
+func TestGetDownstreamTlsVersion(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionTlsVersion, []byte("TLSv1.3"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamTlsVersion()
+	require.NoError(t, err)
+	require.Equal(t, "TLSv1.3", result)
+}
+
+func TestGetDownstreamSubjectLocalCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionSubjectLocalCert,
+		[]byte("CN=example.com,OU=IT,O=example,L=San Francisco,ST=California,C=US"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamSubjectLocalCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "CN=example.com,OU=IT,O=example,L=San Francisco,ST=California,C=US", result)
+}
+
+func TestGetDownstreamSubjectPeerCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionSubjectPeerCert,
+		[]byte("CN=example.com,OU=IT,O=example,L=San Francisco,ST=California,C=US"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamSubjectPeerCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "CN=example.com,OU=IT,O=example,L=San Francisco,ST=California,C=US", result)
+}
+
+func TestGetDownstreamDnsSanLocalCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionDnsSanLocalCert, []byte("example.com"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamDnsSanLocalCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "example.com", result)
+}
+
+func TestGetDownstreamDnsSanPeerCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionDnsSanPeerCert, []byte("example.com"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamDnsSanPeerCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "example.com", result)
+}
+
+func TestGetDownstreamUriSanLocalCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionUriSanLocalCert, []byte("example.com"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamUriSanLocalCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "example.com", result)
+}
+
+func TestGetDownstreamUriSanPeerCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionUriSanPeerCert, []byte("example.com"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamUriSanPeerCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "example.com", result)
+}
+
+func TestGetDownstreamSha256PeerCertificateDigest(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionSha256PeerCertDigest,
+		[]byte{0x01, 0x02, 0x03, 0x04})
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamSha256PeerCertificateDigest()
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, result)
+}
+
+func TestGetDownstreamTerminationDetails(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(connectionTerminationDetails,
+		[]byte("connection closed"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetDownstreamTerminationDetails()
+	require.NoError(t, err)
+	require.Equal(t, "connection closed", result)
+}

--- a/properties/properties.go
+++ b/properties/properties.go
@@ -1,0 +1,6 @@
+// Package properties provides helper functions for retrieving properties in the Envoy/Istio specific environment.
+//
+// WARNING: There's absolutely no guarantee that all properties will be available across versions, and the availability is totally
+// dependant of the configuration, so users are highly encouraged to ensure that plugins work as expected when deploying
+// the plugins using these properties.
+package properties

--- a/properties/properties.go
+++ b/properties/properties.go
@@ -1,6 +1,6 @@
 // Package properties provides helper functions for retrieving properties in the Envoy/Istio specific environment.
 //
 // WARNING: There's absolutely no guarantee that all properties will be available across versions, and the availability is totally
-// dependant of the configuration, so users are highly encouraged to ensure that plugins work as expected when deploying
+// dependent of the configuration, so users are highly encouraged to ensure that plugins work as expected when deploying
 // the plugins using these properties.
 package properties

--- a/properties/util.go
+++ b/properties/util.go
@@ -29,7 +29,7 @@ func getPropertyUint64(path []string) (uint64, error) {
 }
 
 // getPropertyFloat64 returns a float64 property.
-func getPropertyFloat64(path []string) (float64, error) {
+func getPropertyFloat64(path []string) (float64, error) { //nolint:unused
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
 		return 0, err
@@ -49,7 +49,7 @@ func getPropertyBool(path []string) (bool, error) {
 }
 
 // getPropertyTimestamp returns a timestamp property.
-func getPropertyTimestamp(path []string) (time.Time, error) {
+func getPropertyTimestamp(path []string) (time.Time, error) { //nolint:unused
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
 		return time.Now(), err
@@ -60,7 +60,7 @@ func getPropertyTimestamp(path []string) (time.Time, error) {
 
 // getPropertyByteSliceMap retrieves a complex property object as a map of byte slices.
 // to be used when dealing with mixed type properties
-func getPropertyByteSliceMap(path []string) (map[string][]byte, error) {
+func getPropertyByteSliceMap(path []string) (map[string][]byte, error) { //nolint:unused
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ func getPropertyByteSliceMap(path []string) (map[string][]byte, error) {
 
 // getPropertyStringMap retrieves a complex property object as a map of string
 // to be used when dealing with string only type properties.
-func getPropertyStringMap(path []string) (map[string]string, error) {
+func getPropertyStringMap(path []string) (map[string]string, error) { //nolint:unused
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func getPropertyStringMap(path []string) (map[string]string, error) {
 }
 
 // getPropertyStringSlice retrieves a  complex property object as a string slice.
-func getPropertyStringSlice(path []string) ([]string, error) {
+func getPropertyStringSlice(path []string) ([]string, error) { //nolint:unused
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func getPropertyStringSlice(path []string) ([]string, error) {
 }
 
 // deserializeToStringSlice deserializes the given byte slice to string slice.
-func deserializeToStringSlice(bs []byte) []string {
+func deserializeToStringSlice(bs []byte) []string { //nolint:unused
 	numStrings := int(binary.LittleEndian.Uint32(bs[:4]))
 	ret := make([]string, numStrings)
 	idx := 4
@@ -106,7 +106,7 @@ func deserializeToStringSlice(bs []byte) []string {
 }
 
 // getPropertyByteSliceSlice retrieves a complex property object as a string slice.
-func getPropertyByteSliceSlice(path []string) ([][]byte, error) {
+func getPropertyByteSliceSlice(path []string) ([][]byte, error) { //nolint:unused
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func getPropertyByteSliceSlice(path []string) ([][]byte, error) {
 }
 
 // deserializeToByteSliceSlice deserializes the given bytes to string slice.
-func deserializeToByteSliceSlice(bs []byte) [][]byte {
+func deserializeToByteSliceSlice(bs []byte) [][]byte { //nolint:unused
 	numStrings := int(binary.LittleEndian.Uint32(bs[:4]))
 	ret := make([][]byte, numStrings)
 	idx := 4
@@ -135,37 +135,22 @@ func deserializeToUint64(bytes []byte) uint64 {
 }
 
 // deserializeToFloat64 deserializes the given bytes to float64.
-func deserializeToFloat64(bytes []byte) float64 {
+func deserializeToFloat64(bytes []byte) float64 { //nolint:unused
 	bits := binary.LittleEndian.Uint64(bytes)
 	float := math.Float64frombits(bits)
 	return float
 }
 
 // deserializeToTimestamp deserializes the given bytes to timestamp.
-func deserializeToTimestamp(data []byte) time.Time {
+func deserializeToTimestamp(data []byte) time.Time { //nolint:unused
 	nanos := int64(binary.LittleEndian.Uint64(data))
 	return time.Unix(0, nanos)
-}
-
-// deserializeProtobufToStringSlice deserializes the given bytes to string slice.
-func deserializeProtobufToStringSlice(data []byte) []string {
-	var ret []string
-	i := 0
-	for i < len(data) {
-		i++
-		length := int(data[i])
-		i++
-		str := string(data[i : i+length])
-		ret = append(ret, str)
-		i += length
-	}
-	return ret
 }
 
 // deserializeToByteMap deserializes the byte slice to key value map, used for mixed type maps
 //   - keys are always string
 //   - value are raw byte strings that need further parsing
-func deserializeToByteMap(bs []byte) map[string][]byte {
+func deserializeToByteMap(bs []byte) map[string][]byte { //nolint:unused
 	numHeaders := binary.LittleEndian.Uint32(bs[0:4])
 	var sizeIndex = 4
 	var dataIndex = 4 + 4*2*int(numHeaders)
@@ -190,7 +175,7 @@ func deserializeToByteMap(bs []byte) map[string][]byte {
 // deserializeToStringMap deserializes the bytes to key value map, used for string only type maps
 //   - keys are always string
 //   - value are always string
-func deserializeToStringMap(bs []byte) map[string]string {
+func deserializeToStringMap(bs []byte) map[string]string { //nolint:unused
 	numHeaders := binary.LittleEndian.Uint32(bs[0:4])
 	var sizeIndex = 4
 	var dataIndex = 4 + 4*2*int(numHeaders)

--- a/properties/util.go
+++ b/properties/util.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 )
 
-// getPropertyString returns a string property
+// getPropertyString returns a string property.
 func getPropertyString(path []string) (string, error) {
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
@@ -18,7 +18,7 @@ func getPropertyString(path []string) (string, error) {
 	return string(b), nil
 }
 
-// getPropertyUint64 returns a uint64 property
+// getPropertyUint64 returns a uint64 property.
 func getPropertyUint64(path []string) (uint64, error) {
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
@@ -28,7 +28,7 @@ func getPropertyUint64(path []string) (uint64, error) {
 	return deserializeToUint64(b), nil
 }
 
-// getPropertyFloat64 returns a float64 property
+// getPropertyFloat64 returns a float64 property.
 func getPropertyFloat64(path []string) (float64, error) {
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
@@ -38,7 +38,7 @@ func getPropertyFloat64(path []string) (float64, error) {
 	return deserializeToFloat64(b), nil
 }
 
-// getPropertyBool returns a bool property
+// getPropertyBool returns a bool property.
 func getPropertyBool(path []string) (bool, error) {
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
@@ -48,7 +48,7 @@ func getPropertyBool(path []string) (bool, error) {
 	return b[0] != 0, nil
 }
 
-// getPropertyTimestamp returns a timestamp property
+// getPropertyTimestamp returns a timestamp property.
 func getPropertyTimestamp(path []string) (time.Time, error) {
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
@@ -58,7 +58,7 @@ func getPropertyTimestamp(path []string) (time.Time, error) {
 	return deserializeToTimestamp(b), nil
 }
 
-// getPropertyByteSliceMap retrieves a complex property object as a map of byte slices
+// getPropertyByteSliceMap retrieves a complex property object as a map of byte slices.
 // to be used when dealing with mixed type properties
 func getPropertyByteSliceMap(path []string) (map[string][]byte, error) {
 	b, err := proxywasm.GetProperty(path)
@@ -70,7 +70,7 @@ func getPropertyByteSliceMap(path []string) (map[string][]byte, error) {
 }
 
 // getPropertyStringMap retrieves a complex property object as a map of string
-// to be used when dealing with string only type properties
+// to be used when dealing with string only type properties.
 func getPropertyStringMap(path []string) (map[string]string, error) {
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
@@ -80,7 +80,7 @@ func getPropertyStringMap(path []string) (map[string]string, error) {
 	return deserializeToStringMap(b), nil
 }
 
-// getPropertyStringSlice retrieves a  complex property object as a string slice
+// getPropertyStringSlice retrieves a  complex property object as a string slice.
 func getPropertyStringSlice(path []string) ([]string, error) {
 	b, err := proxywasm.GetProperty(path)
 	if err != nil {
@@ -162,7 +162,7 @@ func deserializeProtobufToStringSlice(data []byte) []string {
 	return ret
 }
 
-// deserialize byte slice to key value map, used for mixed type maps
+// deserializeToByteMap deserializes the byte slice to key value map, used for mixed type maps
 //   - keys are always string
 //   - value are raw byte strings that need further parsing
 func deserializeToByteMap(bs []byte) map[string][]byte {

--- a/properties/util.go
+++ b/properties/util.go
@@ -1,0 +1,213 @@
+package properties
+
+import (
+	"encoding/binary"
+	"math"
+	"time"
+	"unsafe"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+)
+
+// getPropertyString returns a string property
+func getPropertyString(path []string) (string, error) {
+	b, err := proxywasm.GetProperty(path)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// getPropertyUint64 returns a uint64 property
+func getPropertyUint64(path []string) (uint64, error) {
+	b, err := proxywasm.GetProperty(path)
+	if err != nil {
+		return 0, err
+	}
+
+	return deserializeToUint64(b), nil
+}
+
+// getPropertyFloat64 returns a float64 property
+func getPropertyFloat64(path []string) (float64, error) {
+	b, err := proxywasm.GetProperty(path)
+	if err != nil {
+		return 0, err
+	}
+
+	return deserializeToFloat64(b), nil
+}
+
+// getPropertyBool returns a bool property
+func getPropertyBool(path []string) (bool, error) {
+	b, err := proxywasm.GetProperty(path)
+	if err != nil {
+		return false, err
+	}
+
+	return b[0] != 0, nil
+}
+
+// getPropertyTimestamp returns a timestamp property
+func getPropertyTimestamp(path []string) (time.Time, error) {
+	b, err := proxywasm.GetProperty(path)
+	if err != nil {
+		return time.Now(), err
+	}
+
+	return deserializeToTimestamp(b), nil
+}
+
+// getPropertyByteSliceMap retrieves a complex property object as a map of byte slices
+// to be used when dealing with mixed type properties
+func getPropertyByteSliceMap(path []string) (map[string][]byte, error) {
+	b, err := proxywasm.GetProperty(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return deserializeToByteMap(b), nil
+}
+
+// getPropertyStringMap retrieves a complex property object as a map of string
+// to be used when dealing with string only type properties
+func getPropertyStringMap(path []string) (map[string]string, error) {
+	b, err := proxywasm.GetProperty(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return deserializeToStringMap(b), nil
+}
+
+// getPropertyStringSlice retrieves a  complex property object as a string slice
+func getPropertyStringSlice(path []string) ([]string, error) {
+	b, err := proxywasm.GetProperty(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return deserializeToStringSlice(b), nil
+}
+
+// deserializeToStringSlice deserializes the given byte slice to string slice.
+func deserializeToStringSlice(bs []byte) []string {
+	numStrings := int(binary.LittleEndian.Uint32(bs[:4]))
+	ret := make([]string, numStrings)
+	idx := 4
+	dataIdx := 4 + 8*numStrings
+	for i := 0; i < numStrings; i++ {
+		strLen := int(binary.LittleEndian.Uint64(bs[idx : idx+8]))
+		idx += 8
+		ret[i] = string(bs[dataIdx : dataIdx+strLen])
+		dataIdx += strLen + 2
+	}
+	return ret
+}
+
+// getPropertyByteSliceSlice retrieves a complex property object as a string slice.
+func getPropertyByteSliceSlice(path []string) ([][]byte, error) {
+	b, err := proxywasm.GetProperty(path)
+	if err != nil {
+		return nil, err
+	}
+	return deserializeToByteSliceSlice(b), nil
+}
+
+// deserializeToByteSliceSlice deserializes the given bytes to string slice.
+func deserializeToByteSliceSlice(bs []byte) [][]byte {
+	numStrings := int(binary.LittleEndian.Uint32(bs[:4]))
+	ret := make([][]byte, numStrings)
+	idx := 4
+	dataIdx := 4 + 8*numStrings
+	for i := 0; i < numStrings; i++ {
+		strLen := int(binary.LittleEndian.Uint64(bs[idx : idx+8]))
+		idx += 8
+		ret[i] = bs[dataIdx : dataIdx+strLen]
+		dataIdx += strLen + 2
+	}
+	return ret
+}
+
+// deserializeToUint64 deserializes  the given bytes  to uint64.
+func deserializeToUint64(bytes []byte) uint64 {
+	return binary.LittleEndian.Uint64(bytes)
+}
+
+// deserializeToFloat64 deserializes the given bytes to float64.
+func deserializeToFloat64(bytes []byte) float64 {
+	bits := binary.LittleEndian.Uint64(bytes)
+	float := math.Float64frombits(bits)
+	return float
+}
+
+// deserializeToTimestamp deserializes the given bytes to timestamp.
+func deserializeToTimestamp(data []byte) time.Time {
+	nanos := int64(binary.LittleEndian.Uint64(data))
+	return time.Unix(0, nanos)
+}
+
+// deserializeProtobufToStringSlice deserializes the given bytes to string slice.
+func deserializeProtobufToStringSlice(data []byte) []string {
+	var ret []string
+	i := 0
+	for i < len(data) {
+		i++
+		length := int(data[i])
+		i++
+		str := string(data[i : i+length])
+		ret = append(ret, str)
+		i += length
+	}
+	return ret
+}
+
+// deserialize byte slice to key value map, used for mixed type maps
+//   - keys are always string
+//   - value are raw byte strings that need further parsing
+func deserializeToByteMap(bs []byte) map[string][]byte {
+	numHeaders := binary.LittleEndian.Uint32(bs[0:4])
+	var sizeIndex = 4
+	var dataIndex = 4 + 4*2*int(numHeaders)
+	ret := make(map[string][]byte)
+	for i := 0; i < int(numHeaders); i++ {
+		keySize := int(binary.LittleEndian.Uint32(bs[sizeIndex : sizeIndex+4]))
+		sizeIndex += 4
+		keyPtr := bs[dataIndex : dataIndex+keySize]
+		key := *(*string)(unsafe.Pointer(&keyPtr))
+		dataIndex += keySize + 1
+
+		valueSize := int(binary.LittleEndian.Uint32(bs[sizeIndex : sizeIndex+4]))
+		sizeIndex += 4
+		valuePtr := bs[dataIndex : dataIndex+valueSize]
+		value := *(*[]byte)(unsafe.Pointer(&valuePtr))
+		dataIndex += valueSize + 1
+		ret[key] = value
+	}
+	return ret
+}
+
+// deserializeToStringMap deserializes the bytes to key value map, used for string only type maps
+//   - keys are always string
+//   - value are always string
+func deserializeToStringMap(bs []byte) map[string]string {
+	numHeaders := binary.LittleEndian.Uint32(bs[0:4])
+	var sizeIndex = 4
+	var dataIndex = 4 + 4*2*int(numHeaders)
+	ret := make(map[string]string, numHeaders)
+	for i := 0; i < int(numHeaders); i++ {
+		keySize := int(binary.LittleEndian.Uint32(bs[sizeIndex : sizeIndex+4]))
+		sizeIndex += 4
+		keyPtr := bs[dataIndex : dataIndex+keySize]
+		key := *(*string)(unsafe.Pointer(&keyPtr))
+		dataIndex += keySize + 1
+
+		valueSize := int(binary.LittleEndian.Uint32(bs[sizeIndex : sizeIndex+4]))
+		sizeIndex += 4
+		valuePtr := bs[dataIndex : dataIndex+valueSize]
+		value := *(*string)(unsafe.Pointer(&valuePtr))
+		dataIndex += valueSize + 1
+		ret[key] = value
+	}
+	return ret
+}

--- a/proxywasm/proxytest/option.go
+++ b/proxywasm/proxytest/option.go
@@ -14,29 +14,47 @@
 
 package proxytest
 
-import "github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+import (
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/internal"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
 
+// EmulatorOption is an option that can be passed to NewHostEmulator.
 type EmulatorOption struct {
 	pluginConfiguration []byte
 	vmConfiguration     []byte
 	vmContext           types.VMContext
+	properties          map[string][]byte
 }
 
+// NewEmulatorOption creates a new EmulatorOption.
 func NewEmulatorOption() *EmulatorOption {
-	return &EmulatorOption{}
+	return &EmulatorOption{vmContext: &types.DefaultVMContext{}}
 }
 
+// WithVMContext sets the VMContext.
 func (o *EmulatorOption) WithVMContext(context types.VMContext) *EmulatorOption {
 	o.vmContext = context
 	return o
 }
 
+// WithPluginConfiguration sets the plugin configuration.
 func (o *EmulatorOption) WithPluginConfiguration(data []byte) *EmulatorOption {
 	o.pluginConfiguration = data
 	return o
 }
 
+// WithVMConfiguration sets the VM configuration.
 func (o *EmulatorOption) WithVMConfiguration(data []byte) *EmulatorOption {
 	o.vmConfiguration = data
+	return o
+}
+
+// WithProperty sets a property. If the property already exists, it will be overwritten.
+func (o *EmulatorOption) WithProperty(path []string, value []byte) *EmulatorOption {
+	if o.properties == nil {
+		o.properties = map[string][]byte{}
+	}
+	o.properties[string(internal.SerializePropertyPath(path))] = value
 	return o
 }

--- a/proxywasm/proxytest/proxytest.go
+++ b/proxywasm/proxytest/proxytest.go
@@ -162,6 +162,10 @@ func NewHostEmulator(opt *EmulatorOption) (host HostEmulator, reset func()) {
 		make(map[string][]byte),
 	}
 
+	for key, value := range opt.properties {
+		emulator.properties[key] = value
+	}
+
 	release := internal.RegisterMockWasmHost(emulator)
 
 	// set up state


### PR DESCRIPTION
part of #396 

This commit creates a new package named `properies` which hosts
helper functions extracted/refactored from https://github.com/boeboe/envoy-wasm-plugins/tree/main/print-properties
