### PR TITLE
New properties API completion

### DIFF
--- a/properties/connection.go
+++ b/properties/connection.go
@@ -1,7 +1,5 @@
 package properties
 
-import "github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
-
 // This file hosts helper functions to retrieve connection-related properties as described in:
 // https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#connection-attributes
 
@@ -26,140 +24,153 @@ var (
 
 // GetDownstreamRemoteAddress returns the remote address of the downstream connection.
 func GetDownstreamRemoteAddress() (string, error) {
-	downstreamRemoteAddress, err := getPropertyString(sourceAddress)
+	result, err := getPropertyString(sourceAddress)
 	if err != nil {
 		return "", err
 	}
-	return downstreamRemoteAddress, nil
+	return result, nil
 }
 
 // GetDownstreamRemotePort returns the remote port of the downstream connection.
 func GetDownstreamRemotePort() (uint64, error) {
-	downstreamRemotePort, err := getPropertyUint64(sourcePort)
+	result, err := getPropertyUint64(sourcePort)
 	if err != nil {
 		return 0, err
 	}
-	return downstreamRemotePort, nil
+	return result, nil
 }
 
 // GetDownstreamLocalAddress returns the local address of the downstream connection.
 func GetDownstreamLocalAddress() (string, error) {
-	downstreamLocalAddress, err := getPropertyString(destinationAddress)
+	result, err := getPropertyString(destinationAddress)
 	if err != nil {
 		return "", err
 	}
-	return downstreamLocalAddress, nil
+	return result, nil
 }
 
 // GetDownstreamLocalPort returns the local port of the downstream connection.
 func GetDownstreamLocalPort() (uint64, error) {
-	downstreamLocalPort, err := getPropertyUint64(destinationPort)
+	result, err := getPropertyUint64(destinationPort)
 	if err != nil {
 		return 0, err
 	}
-	return downstreamLocalPort, nil
+	return result, nil
 }
 
 // GetDownstreamConnectionID returns the connection ID of the downstream connection.
 func GetDownstreamConnectionID() (uint64, error) {
-	downstreamConnectionId, err := getPropertyUint64(connectionID)
+	result, err := getPropertyUint64(connectionID)
 	if err != nil {
 		return 0, err
 	}
-	return downstreamConnectionId, nil
+	return result, nil
 }
 
 // IsDownstreamConnectionTls returns true if the downstream connection is TLS.
 func IsDownstreamConnectionTls() (bool, error) {
-	downstreamConnectionTls, err := getPropertyBool(connectionMtls)
+	result, err := getPropertyBool(connectionMtls)
 	if err != nil {
 		return false, err
 	}
-	return downstreamConnectionTls, nil
+	return result, nil
 }
 
-// GetDownstreamRequestedServerName returns the requested server name of the downstream connection.
+// GetDownstreamRequestedServerName returns the requested server name of the
+// downstream connection.
 func GetDownstreamRequestedServerName() (string, error) {
-	downstreamRequestedServerName, err := getPropertyString(connectionRequestedServerName)
+	result, err := getPropertyString(connectionRequestedServerName)
 	if err != nil {
 		return "", err
 	}
-	return downstreamRequestedServerName, nil
+	return result, nil
 }
 
 // GetDownstreamTlsVersion returns the TLS version of the downstream connection.
 func GetDownstreamTlsVersion() (string, error) {
-	downstreamTlsVersion, err := getPropertyString(connectionTlsVersion)
+	result, err := getPropertyString(connectionTlsVersion)
 	if err != nil {
 		return "", err
 	}
-	return downstreamTlsVersion, nil
+	return result, nil
 }
 
-// GetDownstreamSubjectLocalCertificate returns the subject field of the local certificate in the downstream TLS connection.
+// GetDownstreamSubjectLocalCertificate returns the subject field of the local
+// certificate in the downstream TLS connection.
 func GetDownstreamSubjectLocalCertificate() (string, error) {
-	downstreamSubjectLocalCertificate, err := getPropertyString(connectionSubjectLocalCert)
+	result, err := getPropertyString(connectionSubjectLocalCert)
 	if err != nil {
 		return "", err
 	}
-	return downstreamSubjectLocalCertificate, nil
+	return result, nil
 }
 
-// GetDownstreamSubjectPeerCertificate returns the subject field of the peer certificate in the downstream TLS connection.
+// GetDownstreamSubjectPeerCertificate returns the subject field of the peer certificate
+// in the downstream TLS connection.
 func GetDownstreamSubjectPeerCertificate() (string, error) {
-	downstreamSubjectPeerCertificate, err := getPropertyString(connectionSubjectPeerCert)
+	result, err := getPropertyString(connectionSubjectPeerCert)
 	if err != nil {
 		return "", err
 	}
-	return downstreamSubjectPeerCertificate, nil
+	return result, nil
 }
 
-// GetDownstreamDnsSanLocalCertificate returns The first DNS entry in the SAN field of the local certificate in the downstream TLS connection.
+// GetDownstreamDnsSanLocalCertificate returns The first DNS entry in the SAN field of
+// the local certificate in the downstream TLS connection.
 func GetDownstreamDnsSanLocalCertificate() (string, error) {
-	downstreamDnsSanLocalCertificate, err := getPropertyString(connectionDnsSanLocalCert)
+	result, err := getPropertyString(connectionDnsSanLocalCert)
 	if err != nil {
 		return "", err
 	}
-	return downstreamDnsSanLocalCertificate, nil
+	return result, nil
 }
 
-// GetDownstreamDnsSanPeerCertificate returns The first DNS entry in the SAN field of the peer certificate in the downstream TLS connection.
+// GetDownstreamDnsSanPeerCertificate returns The first DNS entry in the SAN field of the
+// peer certificate in the downstream TLS connection.
 func GetDownstreamDnsSanPeerCertificate() (string, error) {
-	downstreamDnsSanPeerCertificate, err := getPropertyString(connectionDnsSanPeerCert)
+	result, err := getPropertyString(connectionDnsSanPeerCert)
 	if err != nil {
 		return "", err
 	}
-	return downstreamDnsSanPeerCertificate, nil
+	return result, nil
 }
 
-// GetDownstreamUriSanLocalCertificate returns the first URI entry in the SAN field of the local certificate in the downstream TLS connection
+// GetDownstreamUriSanLocalCertificate returns the first URI entry in the SAN field of the
+// local certificate in the downstream TLS connection
 func GetDownstreamUriSanLocalCertificate() (string, error) {
-	downstreamUriSanLocalCertificate, err := getPropertyString(connectionUriSanLocalCert)
+	result, err := getPropertyString(connectionUriSanLocalCert)
 	if err != nil {
 		return "", err
 	}
-	return downstreamUriSanLocalCertificate, nil
+	return result, nil
 }
 
-// GetDownstreamUriSanPeerCertificate returns The first URI entry in the SAN field of the peer certificate in the downstream TLS connection.
+// GetDownstreamUriSanPeerCertificate returns The first URI entry in the SAN field of the
+// peer certificate in the downstream TLS connection.
 func GetDownstreamUriSanPeerCertificate() (string, error) {
-	downstreamUriSanPeerCertificate, err := getPropertyString(connectionUriSanPeerCert)
+	result, err := getPropertyString(connectionUriSanPeerCert)
 	if err != nil {
 		return "", err
 	}
-	return downstreamUriSanPeerCertificate, nil
+	return result, nil
 }
 
-// GetDownstreamSha256PeerCertificateDigest returns the SHA256 digest of a peer certificate digest of the downstream connection.
-func GetDownstreamSha256PeerCertificateDigest() ([]byte, error) {
-	return proxywasm.GetProperty(connectionSha256PeerCertDigest)
+// GetDownstreamSha256PeerCertificateDigest returns the SHA256 digest of a peer certificate
+// digest of the downstream connection.
+func GetDownstreamSha256PeerCertificateDigest() (string, error) {
+	result, err := getPropertyString(connectionSha256PeerCertDigest)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
 }
 
-// GetDownstreamTerminationDetails returns the internal termination details of the connection (subject to change).
+// GetDownstreamTerminationDetails returns the internal termination details of the connection
+// (subject to change).
 func GetDownstreamTerminationDetails() (string, error) {
-	downstreamTerminationDetails, err := getPropertyString(connectionTerminationDetails)
+	result, err := getPropertyString(connectionTerminationDetails)
 	if err != nil {
 		return "", err
 	}
-	return downstreamTerminationDetails, nil
+	return result, nil
 }

--- a/properties/pilot.go
+++ b/properties/pilot.go
@@ -1,0 +1,218 @@
+package properties
+
+// This file hosts helper functions to retrieve node-metadata-related properties as described in:
+// https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#wasm-attributes
+// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-node
+//
+// The pilot environment variables are described in:
+// https://pkg.go.dev/istio.io/istio/pilot/pkg/model
+
+var (
+	nodeMetaAnnotations         = []string{"node", "metadata", "ANNOTATIONS"}
+	nodeMetaAppContainers       = []string{"node", "metadata", "APP_CONTAINERS"}
+	nodeMetaClusterId           = []string{"node", "metadata", "CLUSTER_ID"}
+	nodeMetaEnvoyPrometheusPort = []string{"node", "metadata", "ENVOY_PROMETHEUS_PORT"}
+	nodeMetaEnvoyStatusPort     = []string{"node", "metadata", "ENVOY_STATUS_PORT"}
+	nodeMetaInstanceIps         = []string{"node", "metadata", "INSTANCE_IPS"}
+	nodeMetaInterceptionMode    = []string{"node", "metadata", "INTERCEPTION_MODE"}
+	nodeMetaIstioProxySha       = []string{"node", "metadata", "ISTIO_PROXY_SHA"}
+	nodeMetaIstioVersion        = []string{"node", "metadata", "ISTIO_VERSION"}
+	nodeMetaLabels              = []string{"node", "metadata", "LABELS"}
+	nodeMetaMeshId              = []string{"node", "metadata", "MESH_ID"}
+	nodeMetaName                = []string{"node", "metadata", "NAME"}
+	nodeMetaNamespace           = []string{"node", "metadata", "NAMESPACE"}
+	nodeMetaNodeName            = []string{"node", "metadata", "NODE_NAME"}
+	nodeMetaOwner               = []string{"node", "metadata", "OWNER"}
+	nodeMetaPilotSan            = []string{"node", "metadata", "PILOT_SAN"}
+	nodeMetaPodPorts            = []string{"node", "metadata", "POD_PORTS"}
+	nodeMetaServiceAccount      = []string{"node", "metadata", "SERVICE_ACCOUNT"}
+	nodeMetaWorkloadName        = []string{"node", "metadata", "WORKLOAD_NAME"}
+)
+
+// GetNodeMetaAnnotations returns the node annotations
+func GetNodeMetaAnnotations() (map[string]string, error) {
+	result, err := getPropertyStringMap(nodeMetaAnnotations)
+	if err != nil {
+		return make(map[string]string), err
+	}
+	return result, nil
+}
+
+// GetNodeMetaAppContainers returns the app containers of the node
+func GetNodeMetaAppContainers() (string, error) {
+	result, err := getPropertyString(nodeMetaAppContainers)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaClusterId returns the cluster ID of the node, which defines the
+// cluster the node belongs to
+func GetNodeMetaClusterId() (string, error) {
+	result, err := getPropertyString(nodeMetaClusterId)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaEnvoyPrometheusPort returns the Envoy Prometheus port of the node
+func GetNodeMetaEnvoyPrometheusPort() (float64, error) {
+	result, err := getPropertyFloat64(nodeMetaEnvoyPrometheusPort)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetNodeMetaEnvoyStatusPort returns the Envoy status port of the node
+func GetNodeMetaEnvoyStatusPort() (float64, error) {
+	result, err := getPropertyFloat64(nodeMetaEnvoyStatusPort)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetNodeMetaInstanceIps returns the instance IPs of the node
+func GetNodeMetaInstanceIps() (string, error) {
+	result, err := getPropertyString(nodeMetaInstanceIps)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaInterceptionMode returns the interception mode of the node
+//
+// Possible values:
+//
+//	REDIRECT	: REDIRECT mode uses iptables REDIRECT to NAT and redirect to Envoy. This mode
+//							loses source IP addresses during redirection
+//	TPROXY		: TPROXY mode uses iptables TPROXY to redirect to Envoy. This mode preserves both
+//							the source and destination IP addresses and ports, so that they can be used for
+//							advanced filtering and manipulation. This mode also configures the sidecar to
+//							run with the CAP_NET_ADMIN capability, which is required to use TPROXY
+//	NONE			: NONE mode does not configure redirect to Envoy at all. This is an advanced
+//							configuration that typically requires changes to user applications.
+func GetNodeMetaInterceptionMode() (IstioTrafficInterceptionMode, error) {
+	result, err := getPropertyString(nodeMetaInterceptionMode)
+	if err != nil {
+		return Redirect, err
+	}
+	mode, err := ParseIstioTrafficInterceptionMode(result)
+	if err != nil {
+		return Redirect, err
+	}
+	return mode, nil
+}
+
+// GetNodeMetaIstioProxySha returns the Istio proxy SHA of the node
+func GetNodeMetaIstioProxySha() (string, error) {
+	result, err := getPropertyString(nodeMetaIstioProxySha)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaIstioVersion returns the Istio version of the node
+func GetNodeMetaIstioVersion() (string, error) {
+	result, err := getPropertyString(nodeMetaIstioVersion)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaLabels returns the labels of the node
+func GetNodeMetaLabels() (map[string]string, error) {
+	result, err := getPropertyStringMap(nodeMetaLabels)
+	if err != nil {
+		return make(map[string]string), err
+	}
+	return result, nil
+}
+
+// GetNodeMetaMeshId returns the mesh ID of the node
+func GetNodeMetaMeshId() (string, error) {
+	result, err := getPropertyString(nodeMetaMeshId)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaName returns the name of the node
+func GetNodeMetaName() (string, error) {
+	result, err := getPropertyString(nodeMetaName)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaNamespace returns the namespace of the node
+func GetNodeMetaNamespace() (string, error) {
+	result, err := getPropertyString(nodeMetaNamespace)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaNodeName returns the node name of the node
+func GetNodeMetaNodeName() (string, error) {
+	result, err := getPropertyString(nodeMetaNodeName)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaOwner returns the owner of the node (opaque string). Typically, this is the
+// owning controller of of the workload instance (ex: k8s deployment for a k8s pod)
+func GetNodeMetaOwner() (string, error) {
+	result, err := getPropertyString(nodeMetaOwner)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaPilotSan returns the pilot SAN (subject alternate names) of the node's xDS server
+func GetNodeMetaPilotSan() ([]string, error) {
+	result, err := getPropertyStringSlice(nodeMetaPilotSan)
+	if err != nil {
+		return make([]string, 0), err
+	}
+	return result, nil
+}
+
+// GetNodeMetaPodPorts returns the pod ports of the node. This is used to lookup named ports
+func GetNodeMetaPodPorts() (string, error) {
+	result, err := getPropertyString(nodeMetaPodPorts)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaServiceAccount returns the service account of the node
+func GetNodeMetaServiceAccount() (string, error) {
+	result, err := getPropertyString(nodeMetaServiceAccount)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaWorkloadName returns the workload name of the node
+func GetNodeMetaWorkloadName() (string, error) {
+	result, err := getPropertyString(nodeMetaWorkloadName)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}

--- a/properties/pilot_test.go
+++ b/properties/pilot_test.go
@@ -42,7 +42,6 @@ func TestGetNodeMetaAnnotations(t *testing.T) {
 			input:  map[string]string{},
 			expect: map[string]string{},
 		},
-		// Add more test cases as needed
 	}
 
 	for _, tt := range tests {
@@ -209,7 +208,6 @@ func TestGetNodeMetaLabels(t *testing.T) {
 			input:  map[string]string{},
 			expect: map[string]string{},
 		},
-		// Add more test cases as needed
 	}
 
 	for _, tt := range tests {

--- a/properties/pilot_test.go
+++ b/properties/pilot_test.go
@@ -1,0 +1,337 @@
+package properties
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+)
+
+func TestGetNodeMetaAnnotations(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]string
+		expect map[string]string
+	}{
+		{
+			name: "Non-Empty Annotations",
+			input: map[string]string{
+				"inject.istio.io/templates":   "gateway",
+				"istio.io/rev":                "default",
+				"kubernetes.io/config.seen":   "2023-10-13T10:39:01.174733724Z",
+				"kubernetes.io/config.source": "api",
+				"prometheus.io/path":          "/stats/prometheus",
+				"prometheus.io/port":          "15020",
+				"prometheus.io/scrape":        "true",
+				"proxy.istio.io/overrides":    `{"containers":[{"name":"istio-proxy","ports":[{"name":"http-envoy-prom","containerPort":15090,"protocol":"TCP"}],"resources":{"limits":{"cpu":"2","memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}},"volumeMounts":[{"name":"kube-api-access-6mm2z","readOnly":true,"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always","securityContext":{"capabilities":{"drop":["ALL"]},"privileged":false,"runAsUser":1337,"runAsGroup":1337,"runAsNonRoot":true,"readOnlyRootFilesystem":true,"allowPrivilegeEscalation":false}}]} sidecar.istio.io/componentLogLevel:wasm:debug sidecar.istio.io/inject:true sidecar.istio.io/status:{"initContainers":null,"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}]`,
+			},
+			expect: map[string]string{
+				"inject.istio.io/templates":   "gateway",
+				"istio.io/rev":                "default",
+				"kubernetes.io/config.seen":   "2023-10-13T10:39:01.174733724Z",
+				"kubernetes.io/config.source": "api",
+				"prometheus.io/path":          "/stats/prometheus",
+				"prometheus.io/port":          "15020",
+				"prometheus.io/scrape":        "true",
+				"proxy.istio.io/overrides":    `{"containers":[{"name":"istio-proxy","ports":[{"name":"http-envoy-prom","containerPort":15090,"protocol":"TCP"}],"resources":{"limits":{"cpu":"2","memory":"1Gi"},"requests":{"cpu":"100m","memory":"128Mi"}},"volumeMounts":[{"name":"kube-api-access-6mm2z","readOnly":true,"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always","securityContext":{"capabilities":{"drop":["ALL"]},"privileged":false,"runAsUser":1337,"runAsGroup":1337,"runAsNonRoot":true,"readOnlyRootFilesystem":true,"allowPrivilegeEscalation":false}}]} sidecar.istio.io/componentLogLevel:wasm:debug sidecar.istio.io/inject:true sidecar.istio.io/status:{"initContainers":null,"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}]`,
+			},
+		},
+		{
+			name:   "Empty Annotations",
+			input:  map[string]string{},
+			expect: map[string]string{},
+		},
+		// Add more test cases as needed
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaAnnotations, serializeStringMap(tt.input))
+			_, reset := proxytest.NewHostEmulator(opt)
+			defer reset()
+
+			result, err := GetNodeMetaAnnotations()
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestGetNodeMetaAppContainers(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaAppContainers, []byte("metadata"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaAppContainers()
+	require.NoError(t, err)
+	require.Equal(t, "metadata", result)
+}
+
+func TestGetNodeMetaClusterId(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaClusterId, []byte("Kubernetes"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaClusterId()
+	require.NoError(t, err)
+	require.Equal(t, "Kubernetes", result)
+}
+
+func TestGetNodeMetaEnvoyPrometheusPort(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaEnvoyPrometheusPort, serializeFloat64(15090))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaEnvoyPrometheusPort()
+	require.NoError(t, err)
+	require.Equal(t, float64(15090), result)
+}
+
+func TestGetNodeMetaEnvoyStatusPort(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaEnvoyStatusPort, serializeFloat64(15021))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaEnvoyStatusPort()
+	require.NoError(t, err)
+	require.Equal(t, float64(15021), result)
+}
+
+func TestGetNodeMetaInstanceIps(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaInstanceIps, []byte("10.244.0.13"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaInstanceIps()
+	require.NoError(t, err)
+	require.Equal(t, "10.244.0.13", result)
+}
+
+func TestGetNodeMetaInterceptionMode(t *testing.T) {
+	tests := []struct {
+		name           string
+		propertyValue  []byte
+		expectedResult IstioTrafficInterceptionMode
+		expectedError  error
+	}{
+		{
+			name:           "Valid TPROXY mode",
+			propertyValue:  []byte("TPROXY"),
+			expectedResult: Tproxy,
+			expectedError:  nil,
+		},
+		{
+			name:           "Valid REDIRECT mode",
+			propertyValue:  []byte("REDIRECT"),
+			expectedResult: Redirect,
+			expectedError:  nil,
+		},
+		{
+			name:           "Valid NONE mode",
+			propertyValue:  []byte("NONE"),
+			expectedResult: None,
+			expectedError:  nil,
+		},
+		{
+			name:           "Invalid mode",
+			propertyValue:  []byte("INVALID_MODE"),
+			expectedResult: Redirect,
+			expectedError:  fmt.Errorf("invalid IstioTrafficInterceptionMode: INVALID_MODE"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaInterceptionMode, test.propertyValue)
+			_, reset := proxytest.NewHostEmulator(opt)
+			defer reset()
+
+			result, err := GetNodeMetaInterceptionMode()
+			if test.expectedError != nil {
+				require.Error(t, err)
+				require.Equal(t, test.expectedError, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.expectedResult, result)
+		})
+	}
+}
+
+func TestGetNodeMetaIstioProxySha(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaIstioProxySha, []byte("3c27a1b0cf381ca854ccc3a2034e88c206928da2"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaIstioProxySha()
+	require.NoError(t, err)
+	require.Equal(t, "3c27a1b0cf381ca854ccc3a2034e88c206928da2", result)
+}
+
+func TestGetNodeMetaIstioVersion(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaIstioVersion, []byte("1.18.2-tetrate-v0"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaIstioVersion()
+	require.NoError(t, err)
+	require.Equal(t, "1.18.2-tetrate-v0", result)
+}
+
+func TestGetNodeMetaLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]string
+		expect map[string]string
+	}{
+		{
+			name: "Non-Empty Labels",
+			input: map[string]string{
+				"app":                                 "istio-ingress",
+				"istio":                               "ingress",
+				"istio-locality":                      "region1",
+				"service.istio.io/canonical-name":     "istio-ingress",
+				"service.istio.io/canonical-revision": "latest",
+				"sidecar.istio.io/inject":             "true",
+			},
+			expect: map[string]string{
+				"app":                                 "istio-ingress",
+				"istio":                               "ingress",
+				"istio-locality":                      "region1",
+				"service.istio.io/canonical-name":     "istio-ingress",
+				"service.istio.io/canonical-revision": "latest",
+				"sidecar.istio.io/inject":             "true",
+			},
+		},
+		{
+			name:   "Empty Labels",
+			input:  map[string]string{},
+			expect: map[string]string{},
+		},
+		// Add more test cases as needed
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaLabels, serializeStringMap(tt.input))
+			_, reset := proxytest.NewHostEmulator(opt)
+			defer reset()
+
+			result, err := GetNodeMetaLabels()
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestGetNodeMetaMeshId(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaMeshId, []byte("cluster.local"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaMeshId()
+	require.NoError(t, err)
+	require.Equal(t, "cluster.local", result)
+}
+
+func TestGetNodeMetaName(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaName, []byte("istio-ingress-67cddc6d57-kk2cr"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaName()
+	require.NoError(t, err)
+	require.Equal(t, "istio-ingress-67cddc6d57-kk2cr", result)
+}
+
+func TestGetNodeMetaNamespace(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaNamespace, []byte("istio-ingress"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaNamespace()
+	require.NoError(t, err)
+	require.Equal(t, "istio-ingress", result)
+}
+
+func TestGetNodeMetaNodeName(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaNodeName, []byte("istio-wasm-control-plane"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaNodeName()
+	require.NoError(t, err)
+	require.Equal(t, "istio-wasm-control-plane", result)
+}
+
+func TestGetNodeMetaOwner(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaOwner, []byte("kubernetes://apis/apps/v1/namespaces/istio-ingress/deployments/istio-ingress"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaOwner()
+	require.NoError(t, err)
+	require.Equal(t, "kubernetes://apis/apps/v1/namespaces/istio-ingress/deployments/istio-ingress", result)
+}
+
+func TestGetNodeMetaPilotSan(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []string
+		expect []string
+	}{
+		{
+			name:   "Single SAN",
+			input:  []string{"istiod.istio-system.svc"},
+			expect: []string{"istiod.istio-system.svc"},
+		},
+		{
+			name:   "Multiple SANs",
+			input:  []string{"istiod.istio-system.svc", "istiod.istio-system.svc.cluster.local"},
+			expect: []string{"istiod.istio-system.svc", "istiod.istio-system.svc.cluster.local"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaPilotSan, serializeStringSlice(tt.input))
+			_, reset := proxytest.NewHostEmulator(opt)
+			defer reset()
+
+			result, err := GetNodeMetaPilotSan()
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestGetNodeMetaPodPorts(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaPodPorts, []byte(`[{"name":"http-envoy-prom","containerPort":15090,"protocol":"TCP"}]`))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaPodPorts()
+	require.NoError(t, err)
+	require.Equal(t, `[{"name":"http-envoy-prom","containerPort":15090,"protocol":"TCP"}]`, result)
+}
+
+func TestGetNodeMetaServiceAccount(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaServiceAccount, []byte("istio-ingress"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaServiceAccount()
+	require.NoError(t, err)
+	require.Equal(t, "istio-ingress", result)
+}
+
+func TestGetNodeMetaWorkloadName(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaWorkloadName, []byte("istio-ingress"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaWorkloadName()
+	require.NoError(t, err)
+	require.Equal(t, "istio-ingress", result)
+}

--- a/properties/pilot_test.go
+++ b/properties/pilot_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
 )
 

--- a/properties/proxyconfig.go
+++ b/properties/proxyconfig.go
@@ -1,0 +1,254 @@
+package properties
+
+import (
+	"fmt"
+)
+
+// This file hosts helper functions to retrieve node-metadata-related properties as described in:
+// https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#wasm-attributes
+// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-node
+//
+// The ProxyConfig variables are described in:
+// https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig
+
+var (
+	nodeMetaProxyConfigBinaryPath                     = []string{"node", "metadata", "PROXY_CONFIG", "binaryPath"}
+	nodeMetaProxyConfigConcurrency                    = []string{"node", "metadata", "PROXY_CONFIG", "concurrency"}
+	nodeMetaProxyConfigConfigPath                     = []string{"node", "metadata", "PROXY_CONFIG", "configPath"}
+	nodeProxyConfigControlPlaneAuthPolicy             = []string{"node", "metadata", "PROXY_CONFIG", "controlPlaneAuthPolicy"}
+	nodeProxyConfigDiscoveryAddress                   = []string{"node", "metadata", "PROXY_CONFIG", "discoveryAddress"}
+	nodeProxyConfigDrainDuration                      = []string{"node", "metadata", "PROXY_CONFIG", "drainDuration"}
+	nodeProxyConfigExtraStatTags                      = []string{"node", "metadata", "PROXY_CONFIG", "extraStatTags"}
+	nodeProxyConfigHoldApplicationUntilProxyStarts    = []string{"node", "metadata", "PROXY_CONFIG", "holdApplicationUntilProxyStarts"}
+	nodeProxyConfigProxyAdminPort                     = []string{"node", "metadata", "PROXY_CONFIG", "proxyAdminPort"}
+	nodeProxyConfigProxyStatsMatcherInclusionPrefixes = []string{"node", "metadata", "PROXY_CONFIG", "proxyStatsMatcher", "inclusionPrefixes"}
+	nodeProxyConfigProxyStatsMatcherInclusionRegexps  = []string{"node", "metadata", "PROXY_CONFIG", "proxyStatsMatcher", "inclusionRegexps"}
+	nodeProxyConfigProxyStatsMatcherInclusionSuffixes = []string{"node", "metadata", "PROXY_CONFIG", "proxyStatsMatcher", "inclusionSuffixes"}
+	nodeProxyConfigServiceCluster                     = []string{"node", "metadata", "PROXY_CONFIG", "serviceCluster"}
+	nodeProxyConfigStatNameLength                     = []string{"node", "metadata", "PROXY_CONFIG", "statNameLength"}
+	nodeProxyConfigStatusPort                         = []string{"node", "metadata", "PROXY_CONFIG", "statusPort"}
+	nodeProxyConfigTerminationDrainDuration           = []string{"node", "metadata", "PROXY_CONFIG", "terminationDrainDuration"}
+	nodeProxyConfigTracingDatadogAddress              = []string{"node", "metadata", "PROXY_CONFIG", "tracing", "datadog", "address"}
+	nodeProxyConfigTracingOpenCensusAgentAddress      = []string{"node", "metadata", "PROXY_CONFIG", "tracing", "opencensusagent", "address"}
+	nodeProxyConfigTracingZipkinAddress               = []string{"node", "metadata", "PROXY_CONFIG", "tracing", "zipkin", "address"}
+)
+
+// GetNodeMetaProxyConfigBinaryPath returns the path to the proxy binary
+func GetNodeMetaProxyConfigBinaryPath() (string, error) {
+	result, err := getPropertyString(nodeMetaProxyConfigBinaryPath)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeMetaProxyConfigConcurrency returns the concurrency configuration of the proxy which
+// is the number of worker threads to run. If unset, this will be automatically determined based
+// on CPU requests/limits. If set to 0, all cores on the machine will be used. Default is 2 worker
+// threads
+func GetNodeMetaProxyConfigConcurrency() (float64, error) {
+	result, err := getPropertyFloat64(nodeMetaProxyConfigConcurrency)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetNodeMetaProxyConfigConfigPath returns the path to the proxy configuration, Proxy agent
+// generates the actual configuration and stores it in this directory
+func GetNodeMetaProxyConfigConfigPath() (string, error) {
+	result, err := getPropertyString(nodeMetaProxyConfigConfigPath)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigControlPlaneAuthPolicy returns the control plane authentication policy of
+// the proxy. The authenticationPolicy defines how the proxy is authenticated when it connects
+// to the control plane. Default is set to MUTUAL_TLS
+func GetNodeProxyConfigControlPlaneAuthPolicy() (string, error) {
+	result, err := getPropertyString(nodeProxyConfigControlPlaneAuthPolicy)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigDiscoveryAddress returns the discovery address of the proxy. The discovery
+// service exposes xDS over an mTLS connection. The inject configuration may override this value
+func GetNodeProxyConfigDiscoveryAddress() (string, error) {
+	result, err := getPropertyString(nodeProxyConfigDiscoveryAddress)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigDrainDuration returns the drain duration of the proxy, the time in seconds
+// that Envoy will drain connections during a hot restart. MUST be >=1s (e.g., 1s/1m/1h).
+// Default drain duration is 45s
+func GetNodeProxyConfigDrainDuration() (string, error) {
+	result, err := getPropertyString(nodeProxyConfigDrainDuration)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigExtraStatTags returns the extra stat tags of the proxy to extract from the
+// in-proxy Istio telemetry. These extra tags can be added by configuring the telemetry extension.
+// Each additional tag needs to be present in this list. Extra tags emitted by the telemetry
+// extensions must be listed here so that they can be processed and exposed as Prometheus metrics
+func GetNodeProxyConfigExtraStatTags() ([]string, error) {
+	result, err := getPropertyStringSlice(nodeProxyConfigExtraStatTags)
+	if err != nil {
+		return make([]string, 0), err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigHoldApplicationUntilProxyStarts returns whether to hold the application until
+// the proxy starts. A boolean flag for enabling/disabling the holdApplicationUntilProxyStarts
+// behavior. This feature adds hooks to delay application startup until the pod proxy is ready to
+// accept traffic, mitigating some startup race conditions. Default value is ‘false’
+func GetNodeProxyConfigHoldApplicationUntilProxyStarts() (bool, error) {
+	result, err := getPropertyBool(nodeProxyConfigHoldApplicationUntilProxyStarts)
+	if err != nil {
+		return false, err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigProxyAdminPort returns the admin port of the proxy for administrative commands.
+// Default port is 15000
+func GetNodeProxyConfigProxyAdminPort() (float64, error) {
+	result, err := getPropertyFloat64(nodeProxyConfigProxyAdminPort)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigProxyStatsMatcher returns the proxy stats matcher, which defines
+// configuration for reporting custom Envoy stats. To reduce memory and CPU overhead
+// from Envoy stats system, Istio proxies by default create and expose only a subset of Envoy
+// stats. This option is to control creation of additional Envoy stats with prefix, suffix,
+// and regex expressions match on the name of the stats. This replaces the stats inclusion
+// annotations (sidecar.istio.io/statsInclusionPrefixes, sidecar.istio.io/statsInclusionRegexps,
+// and sidecar.istio.io/statsInclusionSuffixes)
+func GetNodeProxyConfigProxyStatsMatcher() (IstioProxyStatsMatcher, error) {
+	var matcher IstioProxyStatsMatcher
+	var errorsCount int
+
+	prefixes, err := getPropertyStringSlice(nodeProxyConfigProxyStatsMatcherInclusionPrefixes)
+	if err != nil {
+		errorsCount++
+	} else {
+		matcher.InclusionPrefixes = prefixes
+	}
+
+	regexps, err := getPropertyStringSlice(nodeProxyConfigProxyStatsMatcherInclusionRegexps)
+	if err != nil {
+		errorsCount++
+	} else {
+		matcher.InclusionRegexps = regexps
+	}
+
+	suffixes, err := getPropertyStringSlice(nodeProxyConfigProxyStatsMatcherInclusionSuffixes)
+	if err != nil {
+		errorsCount++
+	} else {
+		matcher.InclusionSuffixes = suffixes
+	}
+
+	if errorsCount == 3 {
+		return IstioProxyStatsMatcher{}, fmt.Errorf("failed to fetch any components of IstioProxyStatsMatcher")
+	}
+
+	return matcher, nil
+}
+
+// GetNodeProxyConfigServiceCluster returns the name of the service cluster of the proxy
+// that is shared by all Envoy instances. This setting corresponds to --service-cluster flag
+// in Envoy. In a typical Envoy deployment, the service-cluster flag is used to identify the
+// caller, for source-based routing scenarios. Since Istio does not assign a local service
+// version to each Envoy instance, the name is same for all of them. However, the source/caller’s
+// identity (e.g., IP address) is encoded in the --service-node flag when launching Envoy.
+// When the RDS service receives API calls from Envoy, it uses the value of the service-node
+// flag to compute routes that are relative to the service instances located at that IP address
+func GetNodeProxyConfigServiceCluster() (string, error) {
+	result, err := getPropertyString(nodeProxyConfigServiceCluster)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigStatNameLength returns the stat name length of the proxy, The length
+// of the name field is determined by the length of a name field in a service and the set
+// of labels that comprise a particular version of the service. The default value is set
+// to 189 characters. Envoy’s internal metrics take up 67 characters, for a total of 256
+// character name per metric. Increase the value of this field if you find that the metrics
+// from Envoys are truncated
+func GetNodeProxyConfigStatNameLength() (float64, error) {
+	result, err := getPropertyFloat64(nodeProxyConfigStatNameLength)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigStatusPort returns the port on which the agent should listen
+// for administrative commands such as readiness probe. Default is set to port 15020
+func GetNodeProxyConfigStatusPort() (float64, error) {
+	result, err := getPropertyFloat64(nodeProxyConfigStatusPort)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigTerminationDrainDuration returns the stat name length of the proxy,
+// the amount of time allowed for connections to complete on proxy shutdown. On receiving
+// SIGTERM or SIGINT, istio-agent tells the active Envoy to start draining, preventing
+// any new connections and allowing existing connections to complete. It then sleeps for
+// the termination_drain_duration and then kills any remaining active Envoy processes.
+// If not set, a default of 5s will be applied
+func GetNodeProxyConfigTerminationDrainDuration() (string, error) {
+	result, err := getPropertyString(nodeProxyConfigTerminationDrainDuration)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigTracingDatadogAddress returns the address of the Datadog
+// service (e.g. datadog-agent.sre.svc.cluster.local:8126)
+func GetNodeProxyConfigTracingDatadogAddress() (string, error) {
+	result, err := getPropertyString(nodeProxyConfigTracingDatadogAddress)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigTracingOpenCensusAgentAddress returns the gRPC address for
+// the OpenCensus agent (e.g. dns://authority/host:port or unix:path)
+func GetNodeProxyConfigTracingOpenCensusAgentAddress() (string, error) {
+	result, err := getPropertyString(nodeProxyConfigTracingOpenCensusAgentAddress)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeProxyConfigTracingZipkinAddress returns address of the Zipkin service
+// (e.g. zipkin.sre.svc.cluster.local:9411)
+func GetNodeProxyConfigTracingZipkinAddress() (string, error) {
+	result, err := getPropertyString(nodeProxyConfigTracingZipkinAddress)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}

--- a/properties/proxyconfig_test.go
+++ b/properties/proxyconfig_test.go
@@ -1,0 +1,264 @@
+package properties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+)
+
+func TestGetNodeMetaProxyConfigBinaryPath(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaProxyConfigBinaryPath, []byte("/usr/local/bin/envoy"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaProxyConfigBinaryPath()
+	require.NoError(t, err)
+	require.Equal(t, "/usr/local/bin/envoy", result)
+}
+
+func TestGetNodeMetaProxyConfigConcurrency(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaProxyConfigConcurrency, serializeFloat64(4))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaProxyConfigConcurrency()
+	require.NoError(t, err)
+	require.Equal(t, float64(4), result)
+}
+
+func TestGetNodeMetaProxyConfigConfigPath(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeMetaProxyConfigConfigPath, []byte("./etc/istio/proxy"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeMetaProxyConfigConfigPath()
+	require.NoError(t, err)
+	require.Equal(t, "./etc/istio/proxy", result)
+}
+
+func TestGetNodeProxyConfigControlPlaneAuthPolicy(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigControlPlaneAuthPolicy, []byte("MUTUAL_TLS"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigControlPlaneAuthPolicy()
+	require.NoError(t, err)
+	require.Equal(t, "MUTUAL_TLS", result)
+}
+
+func TestGetNodeProxyConfigDiscoveryAddress(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigDiscoveryAddress, []byte("istiod.istio-system.svc:15012"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigDiscoveryAddress()
+	require.NoError(t, err)
+	require.Equal(t, "istiod.istio-system.svc:15012", result)
+}
+
+func TestGetNodeProxyConfigDrainDuration(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigDrainDuration, []byte("45s"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigDrainDuration()
+	require.NoError(t, err)
+	require.Equal(t, "45s", result)
+}
+
+func TestGetNodeProxyConfigExtraStatTags(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigExtraStatTags, serializeStringSlice([]string{"tag1", "tag2", "tag3"}))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigExtraStatTags()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"tag1", "tag2", "tag3"}, result)
+}
+
+func TestGetNodeProxyConfigHoldApplicationUntilProxyStarts(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    bool
+		expected bool
+	}{
+		{
+			name:     "Test with HoldApplicationUntilProxyStarts true",
+			input:    true,
+			expected: true,
+		},
+		{
+			name:     "Test with HoldApplicationUntilProxyStarts false",
+			input:    false,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigHoldApplicationUntilProxyStarts, serializeBool(tt.input))
+			_, reset := proxytest.NewHostEmulator(opt)
+			defer reset()
+
+			result, err := GetNodeProxyConfigHoldApplicationUntilProxyStarts()
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetNodeProxyConfigProxyAdminPort(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigProxyAdminPort, serializeFloat64(15000))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigProxyAdminPort()
+	require.NoError(t, err)
+	require.Equal(t, float64(15000), result)
+}
+
+func TestGetNodeProxyConfigProxyStatsMatcher(t *testing.T) {
+	tests := []struct {
+		name             string
+		emulatorOption   *proxytest.EmulatorOption
+		expectedMatcher  IstioProxyStatsMatcher
+		expectError      bool
+		expectedErrorMsg string
+	}{
+		{
+			name: "full matcher",
+			emulatorOption: proxytest.NewEmulatorOption().
+				WithProperty(nodeProxyConfigProxyStatsMatcherInclusionPrefixes, serializeStringSlice([]string{"prefix1", "prefix2"})).
+				WithProperty(nodeProxyConfigProxyStatsMatcherInclusionRegexps, serializeStringSlice([]string{"regexp1", "regexp2"})).
+				WithProperty(nodeProxyConfigProxyStatsMatcherInclusionSuffixes, serializeStringSlice([]string{"suffix1", "suffix2"})),
+			expectedMatcher: IstioProxyStatsMatcher{
+				InclusionPrefixes: []string{"prefix1", "prefix2"},
+				InclusionRegexps:  []string{"regexp1", "regexp2"},
+				InclusionSuffixes: []string{"suffix1", "suffix2"},
+			},
+			expectError: false,
+		},
+		{
+			name: "only prefixes",
+			emulatorOption: proxytest.NewEmulatorOption().
+				WithProperty(nodeProxyConfigProxyStatsMatcherInclusionPrefixes, serializeStringSlice([]string{"prefix1", "prefix2"})),
+			expectedMatcher: IstioProxyStatsMatcher{
+				InclusionPrefixes: []string{"prefix1", "prefix2"},
+			},
+			expectError: false,
+		},
+		{
+			name: "only regexps",
+			emulatorOption: proxytest.NewEmulatorOption().
+				WithProperty(nodeProxyConfigProxyStatsMatcherInclusionRegexps, serializeStringSlice([]string{"regexp1", "regexp2"})),
+			expectedMatcher: IstioProxyStatsMatcher{
+				InclusionRegexps: []string{"regexp1", "regexp2"},
+			},
+			expectError: false,
+		},
+		{
+			name: "only suffixes",
+			emulatorOption: proxytest.NewEmulatorOption().
+				WithProperty(nodeProxyConfigProxyStatsMatcherInclusionSuffixes, serializeStringSlice([]string{"suffix1", "suffix2"})),
+			expectedMatcher: IstioProxyStatsMatcher{
+				InclusionSuffixes: []string{"suffix1", "suffix2"},
+			},
+			expectError: false,
+		},
+		{
+			name:             "no properties",
+			emulatorOption:   proxytest.NewEmulatorOption(),
+			expectedMatcher:  IstioProxyStatsMatcher{},
+			expectError:      true,
+			expectedErrorMsg: "failed to fetch any components of IstioProxyStatsMatcher",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, reset := proxytest.NewHostEmulator(tt.emulatorOption)
+			defer reset()
+
+			matcher, err := GetNodeProxyConfigProxyStatsMatcher()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedErrorMsg, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedMatcher, matcher)
+			}
+		})
+	}
+}
+
+func TestGetNodeProxyConfigServiceCluster(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigServiceCluster, []byte("service-cluster-name"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigServiceCluster()
+	require.NoError(t, err)
+	require.Equal(t, "service-cluster-name", result)
+}
+
+func TestGetNodeProxyConfigStatNameLength(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigStatNameLength, serializeFloat64(256))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigStatNameLength()
+	require.NoError(t, err)
+	require.Equal(t, float64(256), result)
+}
+
+func TestGetNodeProxyConfigStatusPort(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigStatusPort, serializeFloat64(15020))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigStatusPort()
+	require.NoError(t, err)
+	require.Equal(t, float64(15020), result)
+}
+
+func TestGetNodeProxyConfigTerminationDrainDuration(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigTerminationDrainDuration, []byte("5s"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigTerminationDrainDuration()
+	require.NoError(t, err)
+	require.Equal(t, "5s", result)
+}
+
+func TestGetNodeProxyConfigTracingDatadogAddress(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigTracingDatadogAddress, []byte("datadog-agent.sre.svc.cluster.local:8126"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigTracingDatadogAddress()
+	require.NoError(t, err)
+	require.Equal(t, "datadog-agent.sre.svc.cluster.local:8126", result)
+}
+
+func TestGetNodeProxyConfigTracingOpenCensusAgentAddress(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigTracingOpenCensusAgentAddress, []byte("opencensus-agent.sre.svc.cluster.local:55678"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigTracingOpenCensusAgentAddress()
+	require.NoError(t, err)
+	require.Equal(t, "opencensus-agent.sre.svc.cluster.local:55678", result)
+}
+
+func TestGetNodeProxyConfigTracingZipkinAddress(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeProxyConfigTracingZipkinAddress, []byte("zipkin.sre.svc.cluster.local:9411"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeProxyConfigTracingZipkinAddress()
+	require.NoError(t, err)
+	require.Equal(t, "zipkin.sre.svc.cluster.local:9411", result)
+}

--- a/properties/proxyconfig_test.go
+++ b/properties/proxyconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
 )
 

--- a/properties/request.go
+++ b/properties/request.go
@@ -1,0 +1,159 @@
+package properties
+
+import "time"
+
+// This file hosts helper functions to retrieve request-related properties as described in:
+// https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#request-attributes
+
+var (
+	requestPath      = []string{"request", "path"}
+	requestUrlPath   = []string{"request", "url_path"}
+	requestHost      = []string{"request", "host"}
+	requestScheme    = []string{"request", "scheme"}
+	requestMethod    = []string{"request", "method"}
+	requestHeaders   = []string{"request", "headers"}
+	requestReferer   = []string{"request", "referer"}
+	requestUserAgent = []string{"request", "useragent"}
+	requestTime      = []string{"request", "time"}
+	requestId        = []string{"request", "id"}
+	requestProtocol  = []string{"request", "protocol"}
+	requestQuery     = []string{"request", "query"}
+	requestDuration  = []string{"request", "duration"}
+	requestSize      = []string{"request", "size"}
+	requestTotalSize = []string{"request", "total_size"}
+)
+
+// GetRequestPath return the path portion of the URL.
+func GetRequestPath() (string, error) {
+	result, err := getPropertyString(requestPath)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetRequestUrlPath returns the path portion of the URL without the query string.
+func GetRequestUrlPath() (string, error) {
+	result, err := getPropertyString(requestUrlPath)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetRequestHost returns the host portion of the URL.
+func GetRequestHost() (string, error) {
+	result, err := getPropertyString(requestHost)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetRequestScheme returns the scheme portion of the URL e.g. “http”.
+func GetRequestScheme() (string, error) {
+	result, err := getPropertyString(requestScheme)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetRequestMethod returns the request method e.g. “GET”.
+func GetRequestMethod() (string, error) {
+	result, err := getPropertyString(requestMethod)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetRequestHeaders returns all request headers indexed by the lower-cased header name.
+func GetRequestHeaders() (map[string]string, error) {
+	result, err := getPropertyStringMap(requestHeaders)
+	if err != nil {
+		return map[string]string{}, err
+	}
+	return result, nil
+}
+
+// GetRequestReferer returns the referer request header.
+func GetRequestReferer() (string, error) {
+	result, err := getPropertyString(requestReferer)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetRequestUserAgent returns the user agent request header.
+func GetRequestUserAgent() (string, error) {
+	result, err := getPropertyString(requestUserAgent)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetRequestTime returns the UTC time of the first byte received, approximated to nano-seconds.
+func GetRequestTime() (time.Time, error) {
+	result, err := getPropertyTimestamp(requestTime)
+	if err != nil {
+		return time.Now(), err
+	}
+	return result, nil
+}
+
+// GetRequestId returns the request ID corresponding to x-request-id header value.
+func GetRequestId() (string, error) {
+	result, err := getPropertyString(requestId)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetRequestProtocol returns the request protocol (“HTTP/1.0”, “HTTP/1.1”, “HTTP/2”, or “HTTP/3”).
+func GetRequestProtocol() (string, error) {
+	result, err := getPropertyString(requestProtocol)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetRequestQuery returns the query portion of the URL in the format of “name1=value1&name2=value2”.
+func GetRequestQuery() (string, error) {
+	result, err := getPropertyString(requestQuery)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetRequestDuration returns the total duration of the request, approximated to nano-seconds.
+func GetRequestDuration() (uint64, error) {
+	result, err := getPropertyUint64(requestDuration)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetRequestSize returns the size of the request body. Content length header is used if available.
+func GetRequestSize() (uint64, error) {
+	result, err := getPropertyUint64(requestSize)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetRequestTotalSize returns the total size of the request including the approximate uncompressed size of the headers.
+func GetRequestTotalSize() (uint64, error) {
+	result, err := getPropertyUint64(requestTotalSize)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}

--- a/properties/request_test.go
+++ b/properties/request_test.go
@@ -1,0 +1,233 @@
+package properties
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+)
+
+func TestGetRequestPath(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestPath, []byte("/headers"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestPath()
+	require.NoError(t, err)
+	require.Equal(t, "/headers", result)
+}
+
+func TestGetRequestUrlPath(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestUrlPath, []byte("/headers"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestUrlPath()
+	require.NoError(t, err)
+	require.Equal(t, "/headers", result)
+}
+
+func TestGetRequestHost(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestHost, []byte("wasm.httpbin.org"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestHost()
+	require.NoError(t, err)
+	require.Equal(t, "wasm.httpbin.org", result)
+}
+
+func TestGetRequestScheme(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "Request Scheme: HTTP",
+			input:  "http",
+			expect: "http",
+		},
+		{
+			name:   "Request Scheme: HTTPS",
+			input:  "https",
+			expect: "https",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := proxytest.NewEmulatorOption().WithProperty(requestScheme, []byte(tt.input))
+			_, reset := proxytest.NewHostEmulator(opt)
+			defer reset()
+
+			result, err := GetRequestScheme()
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestGetRequestMethod(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestMethod, []byte("GET"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestMethod()
+	require.NoError(t, err)
+	require.Equal(t, "GET", result)
+}
+
+func TestGetRequestHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]string
+		output map[string]string
+	}{
+		{
+			name: "Test with populated map",
+			input: map[string]string{
+				":authority":                  "wasm.httpbin.org",
+				":method":                     "GET",
+				":path":                       "/headers",
+				":scheme":                     "http",
+				"accept":                      "*/*",
+				"user-agent":                  "curl/7.81.0",
+				"x-b3-sampled":                "1",
+				"x-envoy-decorator-operation": "httpbin.org:80/*",
+				"x-envoy-internal":            "true",
+				"x-envoy-peer-metadata":       "ChQKDkFQUF9DT05UQUlORVJTE",
+				"x-envoy-peer-metadata-id":    "router~10.244.0.13~istio-ingress-67cddc6d57-kk2cr.istio-ingress~istio-ingress.svc.cluster.local",
+				"x-forwarded-for":             "10.244.0.1",
+				"x-forwarded-proto":           "http",
+				"x-request-id":                "7490e0f7-87f0-4c81-92aa-8ea3d5896189",
+			},
+			output: map[string]string{
+				":authority":                  "wasm.httpbin.org",
+				":method":                     "GET",
+				":path":                       "/headers",
+				":scheme":                     "http",
+				"accept":                      "*/*",
+				"user-agent":                  "curl/7.81.0",
+				"x-b3-sampled":                "1",
+				"x-envoy-decorator-operation": "httpbin.org:80/*",
+				"x-envoy-internal":            "true",
+				"x-envoy-peer-metadata":       "ChQKDkFQUF9DT05UQUlORVJTE",
+				"x-envoy-peer-metadata-id":    "router~10.244.0.13~istio-ingress-67cddc6d57-kk2cr.istio-ingress~istio-ingress.svc.cluster.local",
+				"x-forwarded-for":             "10.244.0.1",
+				"x-forwarded-proto":           "http",
+				"x-request-id":                "7490e0f7-87f0-4c81-92aa-8ea3d5896189",
+			},
+		},
+		{
+			name:   "Test with empty map",
+			input:  map[string]string{},
+			output: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := proxytest.NewEmulatorOption().WithProperty(requestHeaders, serializeStringMap(tt.input))
+			_, reset := proxytest.NewHostEmulator(opt)
+			defer reset()
+
+			result, err := GetRequestHeaders()
+			require.NoError(t, err)
+			require.Equal(t, tt.output, result)
+		})
+	}
+}
+
+func TestGetRequestReferer(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestReferer, []byte("https://site.com/page"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestReferer()
+	require.NoError(t, err)
+	require.Equal(t, "https://site.com/page", result)
+}
+
+func TestGetRequestUserAgent(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestUserAgent, []byte("curl/7.81.0"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestUserAgent()
+	require.NoError(t, err)
+	require.Equal(t, "curl/7.81.0", result)
+}
+
+func TestGetRequestTime(t *testing.T) {
+	now := time.Now().UTC()
+	opt := proxytest.NewEmulatorOption().WithProperty(requestTime, serializeTimestamp(now))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestTime()
+	require.NoError(t, err)
+	require.Equal(t, now, result)
+}
+
+func TestGetRequestId(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestId, []byte("7490e0f7-87f0-4c81-92aa-8ea3d5896189"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestId()
+	require.NoError(t, err)
+	require.Equal(t, "7490e0f7-87f0-4c81-92aa-8ea3d5896189", result)
+}
+
+func TestGetRequestProtocol(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestProtocol, []byte("HTTP/1.1"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestProtocol()
+	require.NoError(t, err)
+	require.Equal(t, "HTTP/1.1", result)
+}
+
+func TestGetRequestQuery(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestQuery, []byte("?page=1&limit=10"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestQuery()
+	require.NoError(t, err)
+	require.Equal(t, "?page=1&limit=10", result)
+}
+
+func TestGetRequestDuration(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestDuration, serializeUint64(1000))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestDuration()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), result)
+}
+
+func TestGetRequestSize(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestSize, serializeUint64(256))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestSize()
+	require.NoError(t, err)
+	require.Equal(t, uint64(256), result)
+}
+
+func TestGetRequestTotalSize(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(requestTotalSize, serializeUint64(1024))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRequestTotalSize()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1024), result)
+}

--- a/properties/response.go
+++ b/properties/response.go
@@ -1,0 +1,91 @@
+package properties
+
+// This file hosts helper functions to retrieve response-related properties as described in:
+// https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#response-attributes
+
+var (
+	responseCode           = []string{"response", "code"}
+	responseCodeDetails    = []string{"response", "code_details"}
+	responseFlags          = []string{"response", "flags"}
+	responseGrpcStatusCode = []string{"response", "grpc_status"}
+	responseHeaders        = []string{"response", "headers"}
+	responseTrailers       = []string{"response", "trailers"}
+	responseSize           = []string{"response", "size"}
+	responseTotalSize      = []string{"response", "total_size"}
+)
+
+// GetResponseCode returns the response HTTP status code.
+func GetResponseCode() (uint64, error) {
+	result, err := getPropertyUint64(responseCode)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetResponseCodeDetails returns the internal response code details (subject to change).
+func GetResponseCodeDetails() (string, error) {
+	result, err := getPropertyString(responseCodeDetails)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetResponseFlags returns additional details about the response beyond the standard
+// response code encoded as a bit-vector.
+//	
+// https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags
+func GetResponseFlags() (uint64, error) {
+	result, err := getPropertyUint64(responseFlags)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetResponseGrpcStatusCode returns the response gRPC status code.
+func GetResponseGrpcStatusCode() (uint64, error) {
+	result, err := getPropertyUint64(responseGrpcStatusCode)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetResponseHeaders returns all response headers indexed by the lower-cased header name.
+func GetResponseHeaders() (map[string]string, error) {
+	result, err := getPropertyStringMap(responseHeaders)
+	if err != nil {
+		return map[string]string{}, err
+	}
+	return result, nil
+}
+
+// GetResponseTrailers returns all response trailers indexed by the lower-cased trailer name.
+func GetResponseTrailers() (map[string]string, error) {
+	result, err := getPropertyStringMap(responseTrailers)
+	if err != nil {
+		return map[string]string{}, err
+	}
+	return result, nil
+}
+
+// GetResponseSize returns the size of the response body.
+func GetResponseSize() (uint64, error) {
+	result, err := getPropertyUint64(responseSize)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetResponseTotalSize returns the total size of the response including the approximate
+// uncompressed size of the headers and the trailers.
+func GetResponseTotalSize() (uint64, error) {
+	result, err := getPropertyUint64(responseTotalSize)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}

--- a/properties/response.go
+++ b/properties/response.go
@@ -34,7 +34,7 @@ func GetResponseCodeDetails() (string, error) {
 
 // GetResponseFlags returns additional details about the response beyond the standard
 // response code encoded as a bit-vector.
-//	
+//
 // https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags
 func GetResponseFlags() (uint64, error) {
 	result, err := getPropertyUint64(responseFlags)

--- a/properties/response_test.go
+++ b/properties/response_test.go
@@ -1,0 +1,155 @@
+package properties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+)
+
+func TestGetResponseCode(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(responseCode, serializeUint64(200))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetResponseCode()
+	require.NoError(t, err)
+	require.Equal(t, uint64(200), result)
+}
+
+func TestGetResponseCodeDetails(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(responseCodeDetails, []byte("Not Found"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetResponseCodeDetails()
+	require.NoError(t, err)
+	require.Equal(t, "Not Found", result)
+}
+
+func TestGetResponseFlags(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(responseFlags, serializeUint64(123))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetResponseFlags()
+	require.NoError(t, err)
+	require.Equal(t, uint64(123), result)
+}
+
+func TestGetResponseGrpcStatusCode(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(responseGrpcStatusCode, serializeUint64(200))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetResponseGrpcStatusCode()
+	require.NoError(t, err)
+	require.Equal(t, uint64(200), result)
+}
+
+func TestGetResponseHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]string
+		expect map[string]string
+	}{
+		{
+			name: "With Headers",
+			input: map[string]string{
+				":status":                          "200",
+				"access-control-allow-credentials": "true",
+				"access-control-allow-origin":      "*",
+				"connection":                       "keep-alive",
+				"content-length":                   "1383",
+				"content-type":                     "application/json",
+				"date":                             "Fri, 13 Oct 2023 11:38:01 GMT",
+				"server":                           "gunicorn/19.9.0",
+				"x-envoy-upstream-service-time":    "199",
+			},
+			expect: map[string]string{
+				":status":                          "200",
+				"access-control-allow-credentials": "true",
+				"access-control-allow-origin":      "*",
+				"connection":                       "keep-alive",
+				"content-length":                   "1383",
+				"content-type":                     "application/json",
+				"date":                             "Fri, 13 Oct 2023 11:38:01 GMT",
+				"server":                           "gunicorn/19.9.0",
+				"x-envoy-upstream-service-time":    "199",
+			},
+		},
+		{
+			name:   "Empty Headers",
+			input:  map[string]string{},
+			expect: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := proxytest.NewEmulatorOption().WithProperty(responseHeaders, serializeStringMap(tt.input))
+			_, reset := proxytest.NewHostEmulator(opt)
+			defer reset()
+
+			result, err := GetResponseHeaders()
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestGetResponseTrailers(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]string
+		expect map[string]string
+	}{
+		{
+			name: "With Trailers",
+			input: map[string]string{
+				"Expires:": "Wed, 21 Oct 2015 07:28:00 GMT",
+			},
+			expect: map[string]string{
+				"Expires:": "Wed, 21 Oct 2015 07:28:00 GMT",
+			},
+		},
+		{
+			name:   "Empty Trailers",
+			input:  map[string]string{},
+			expect: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := proxytest.NewEmulatorOption().WithProperty(responseTrailers, serializeStringMap(tt.input))
+			_, reset := proxytest.NewHostEmulator(opt)
+			defer reset()
+
+			result, err := GetResponseTrailers()
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestGetResponseSize(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(responseSize, serializeUint64(512))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetResponseSize()
+	require.NoError(t, err)
+	require.Equal(t, uint64(512), result)
+}
+
+func TestGetResponseTotalSize(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(responseTotalSize, serializeUint64(2048))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetResponseTotalSize()
+	require.NoError(t, err)
+	require.Equal(t, uint64(2048), result)
+}

--- a/properties/serialization.go
+++ b/properties/serialization.go
@@ -172,27 +172,29 @@ func deserializeProtoStringSlice(bs []byte) []string {
 func serializeStringMap(m map[string]string) []byte {
 	var buf bytes.Buffer
 	numHeaders := uint32(len(m))
-	binary.Write(&buf, binary.LittleEndian, numHeaders)
+	headerBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(headerBytes, numHeaders)
+	buf.Write(headerBytes)
 	var sizeData bytes.Buffer
 	var data bytes.Buffer
-
 	for key, value := range m {
 		keySize := uint32(len(key))
-		binary.Write(&sizeData, binary.LittleEndian, keySize)
+		keySizeBytes := make([]byte, 4)
+		binary.LittleEndian.PutUint32(keySizeBytes, keySize)
+		sizeData.Write(keySizeBytes)
 		keyData := *(*[]byte)(unsafe.Pointer(&key))
 		data.Write(keyData)
 		data.WriteByte(0)
 		valueSize := uint32(len(value))
-		binary.Write(&sizeData, binary.LittleEndian, valueSize)
+		valueSizeBytes := make([]byte, 4)
+		binary.LittleEndian.PutUint32(valueSizeBytes, valueSize)
+		sizeData.Write(valueSizeBytes)
 		valueData := *(*[]byte)(unsafe.Pointer(&value))
 		data.Write(valueData)
 		data.WriteByte(0)
 	}
-
-	// Combine size data and actual data into the main buffer
 	buf.Write(sizeData.Bytes())
 	buf.Write(data.Bytes())
-
 	return buf.Bytes()
 }
 

--- a/properties/serialization.go
+++ b/properties/serialization.go
@@ -1,0 +1,286 @@
+package properties
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"time"
+	"unsafe"
+)
+
+// serializeBool converts a boolean value to a byte slice representation.
+func serializeBool(value bool) []byte {
+	if value {
+		return []byte{1}
+	}
+	return []byte{0}
+}
+
+// deserializeBool converts a byte slice back to a boolean value.
+func deserializeBool(bs []byte) (bool, error) {
+	if len(bs) == 0 {
+		return false, nil
+	}
+	if len(bs) != 1 {
+		return false, fmt.Errorf("invalid byte slice length for boolean deserialization")
+	}
+	return bs[0] != 0, nil
+}
+
+// serializeByteMap serializes a map where keys are strings and values are raw byte slices.
+// The resulting byte slice can be used for efficient storage or transmission.
+//   - keys are always string
+//   - values are raw byte slices
+func serializeByteSliceMap(data map[string][]byte) []byte {
+	totalSize := 4
+	for key, value := range data {
+		totalSize += 4 + len(key) + 1 + 4 + len(value) + 1
+	}
+	bs := make([]byte, totalSize)
+	binary.LittleEndian.PutUint32(bs[0:4], uint32(len(data)))
+	var sizeIndex = 4
+	var dataIndex = 4 + 4*2*len(data)
+	for key, value := range data {
+		binary.LittleEndian.PutUint32(bs[sizeIndex:sizeIndex+4], uint32(len(key)))
+		sizeIndex += 4
+		copy(bs[dataIndex:dataIndex+len(key)], key)
+		dataIndex += len(key) + 1
+		binary.LittleEndian.PutUint32(bs[sizeIndex:sizeIndex+4], uint32(len(value)))
+		sizeIndex += 4
+		copy(bs[dataIndex:dataIndex+len(value)], value)
+		dataIndex += len(value) + 1
+	}
+	return bs
+}
+
+// deserializeByteMap deserializes the byte slice to key value map, used for mixed type maps
+//   - keys are always string
+//   - value are raw byte strings that need further parsing
+func deserializeByteSliceMap(bs []byte) map[string][]byte { //nolint:unused
+	numHeaders := binary.LittleEndian.Uint32(bs[0:4])
+	var sizeIndex = 4
+	var dataIndex = 4 + 4*2*int(numHeaders)
+	ret := make(map[string][]byte)
+	for i := 0; i < int(numHeaders); i++ {
+		keySize := int(binary.LittleEndian.Uint32(bs[sizeIndex : sizeIndex+4]))
+		sizeIndex += 4
+		keyPtr := bs[dataIndex : dataIndex+keySize]
+		key := *(*string)(unsafe.Pointer(&keyPtr))
+		dataIndex += keySize + 1
+
+		valueSize := int(binary.LittleEndian.Uint32(bs[sizeIndex : sizeIndex+4]))
+		sizeIndex += 4
+		valuePtr := bs[dataIndex : dataIndex+valueSize]
+		value := *(*[]byte)(unsafe.Pointer(&valuePtr))
+		dataIndex += valueSize + 1
+		ret[key] = value
+	}
+	return ret
+}
+
+// serializeByteSliceSlice serializes a slice of byte slices into a single byte slice.
+// The resulting byte slice can be used for efficient storage or transmission.
+// Each byte slice in the input is prefixed with its length, allowing for efficient deserialization.
+func serializeByteSliceSlice(slices [][]byte) []byte {
+	totalSize := 4
+	for _, slice := range slices {
+		totalSize += 8 + len(slice) + 2
+	}
+	bs := make([]byte, totalSize)
+	binary.LittleEndian.PutUint32(bs[:4], uint32(len(slices)))
+	idx := 4
+	dataIdx := 4 + 8*len(slices)
+	for _, slice := range slices {
+		binary.LittleEndian.PutUint64(bs[idx:idx+8], uint64(len(slice)))
+		idx += 8
+		copy(bs[dataIdx:dataIdx+len(slice)], slice)
+		dataIdx += len(slice) + 2
+	}
+	return bs
+}
+
+// deserializeByteSliceSlice deserializes the given bytes to string slice.
+func deserializeByteSliceSlice(bs []byte) [][]byte {
+	numStrings := int(binary.LittleEndian.Uint32(bs[:4]))
+	ret := make([][]byte, numStrings)
+	idx := 4
+	dataIdx := 4 + 8*numStrings
+	for i := 0; i < numStrings; i++ {
+		strLen := int(binary.LittleEndian.Uint64(bs[idx : idx+8]))
+		idx += 8
+		ret[i] = bs[dataIdx : dataIdx+strLen]
+		dataIdx += strLen + 2
+	}
+	return ret
+}
+
+// serializeFloat64 serializes the given float64 to bytes.
+// The resulting byte slice can be used for efficient storage or transmission.
+func serializeFloat64(value float64) []byte {
+	bits := math.Float64bits(value)
+	bs := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bs, bits)
+	return bs
+}
+
+// deserializeFloat64 deserializes the given bytes to float64.
+func deserializeFloat64(bs []byte) float64 {
+	bits := binary.LittleEndian.Uint64(bs)
+	float := math.Float64frombits(bits)
+	return float
+}
+
+// serializeProtoStringSlice serializes a slice of strings into a protobuf-like encoded byte slice.
+// The resulting byte slice can be used for efficient storage or transmission.
+// Each string in the slice is prefixed with its length, allowing for efficient deserialization.
+func serializeProtoStringSlice(strs []string) []byte {
+	var bs []byte
+	for _, str := range strs {
+		if len(str) > 255 {
+			panic("string length exceeds 255 characters")
+		}
+		bs = append(bs, 0x00)
+		bs = append(bs, byte(len(str)))
+		bs = append(bs, []byte(str)...)
+	}
+	return bs
+}
+
+// deserializeProtoStringSlice deserializes a protobuf encoded string slice
+func deserializeProtoStringSlice(bs []byte) []string {
+	ret := make([]string, 0)
+	i := 0
+	for i < len(bs) {
+		i++
+		length := int(bs[i])
+		i++
+		str := string(bs[i : i+length])
+		ret = append(ret, str)
+		i += length
+	}
+	return ret
+}
+
+// serializeStringMap serializes a map of strings to a byte slice.
+//   - keys are always string
+//   - values are always string
+//
+// The resulting byte slice starts with a 4-byte representation of the number of key-value pairs.
+// This is followed by a series of 4-byte representations of the sizes of the keys and values.
+// Finally, the actual key and value data are appended.
+func serializeStringMap(m map[string]string) []byte {
+	var buf bytes.Buffer
+	numHeaders := uint32(len(m))
+	binary.Write(&buf, binary.LittleEndian, numHeaders)
+	var sizeData bytes.Buffer
+	var data bytes.Buffer
+
+	for key, value := range m {
+		keySize := uint32(len(key))
+		binary.Write(&sizeData, binary.LittleEndian, keySize)
+		keyData := *(*[]byte)(unsafe.Pointer(&key))
+		data.Write(keyData)
+		data.WriteByte(0)
+		valueSize := uint32(len(value))
+		binary.Write(&sizeData, binary.LittleEndian, valueSize)
+		valueData := *(*[]byte)(unsafe.Pointer(&value))
+		data.Write(valueData)
+		data.WriteByte(0)
+	}
+
+	// Combine size data and actual data into the main buffer
+	buf.Write(sizeData.Bytes())
+	buf.Write(data.Bytes())
+
+	return buf.Bytes()
+}
+
+// deserializeStringMap deserializes the bytes to key value map, used for string only type maps
+//   - keys are always string
+//   - value are always string
+func deserializeStringMap(bs []byte) map[string]string {
+	numHeaders := binary.LittleEndian.Uint32(bs[0:4])
+	var sizeIndex = 4
+	var dataIndex = 4 + 4*2*int(numHeaders)
+	ret := make(map[string]string, numHeaders)
+	for i := 0; i < int(numHeaders); i++ {
+		keySize := int(binary.LittleEndian.Uint32(bs[sizeIndex : sizeIndex+4]))
+		sizeIndex += 4
+		keyPtr := bs[dataIndex : dataIndex+keySize]
+		key := *(*string)(unsafe.Pointer(&keyPtr))
+		dataIndex += keySize + 1
+
+		valueSize := int(binary.LittleEndian.Uint32(bs[sizeIndex : sizeIndex+4]))
+		sizeIndex += 4
+		valuePtr := bs[dataIndex : dataIndex+valueSize]
+		value := *(*string)(unsafe.Pointer(&valuePtr))
+		dataIndex += valueSize + 1
+		ret[key] = value
+	}
+	return ret
+}
+
+// serializeStringSlice serializes a slice of strings into a single byte slice.
+// The resulting byte slice can be used for efficient storage or transmission.
+// Each string in the input is prefixed with its length, allowing for efficient deserialization.
+func serializeStringSlice(strings []string) []byte {
+	totalSize := 4
+	for _, str := range strings {
+		totalSize += 8 + len(str) + 2
+	}
+	bs := make([]byte, totalSize)
+	binary.LittleEndian.PutUint32(bs[:4], uint32(len(strings)))
+	idx := 4
+	dataIdx := 4 + 8*len(strings)
+	for _, str := range strings {
+		binary.LittleEndian.PutUint64(bs[idx:idx+8], uint64(len(str)))
+		idx += 8
+		copy(bs[dataIdx:dataIdx+len(str)], str)
+		dataIdx += len(str) + 2
+	}
+	return bs
+}
+
+// deserializeStringSlice deserializes the given byte slice to string slice.
+func deserializeStringSlice(bs []byte) []string {
+	numStrings := int(binary.LittleEndian.Uint32(bs[:4]))
+	ret := make([]string, numStrings)
+	idx := 4
+	dataIdx := 4 + 8*numStrings
+	for i := 0; i < numStrings; i++ {
+		strLen := int(binary.LittleEndian.Uint64(bs[idx : idx+8]))
+		idx += 8
+		ret[i] = string(bs[dataIdx : dataIdx+strLen])
+		dataIdx += strLen + 2
+	}
+	return ret
+}
+
+// serializeTimestamp serializes the given timestamp to bytes.
+// The resulting byte slice can be used for efficient storage or transmission.
+func serializeTimestamp(timestamp time.Time) []byte {
+	nanos := timestamp.UnixNano()
+	bs := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bs, uint64(nanos))
+	return bs
+}
+
+// deserializeTimestamp deserializes the given bytes to timestamp.
+func deserializeTimestamp(bs []byte) time.Time {
+	nanos := int64(binary.LittleEndian.Uint64(bs))
+	return time.Unix(0, nanos)
+}
+
+// serializeUint64 serializes the given uint64 to bytes.
+// The resulting byte slice can be used for efficient storage or transmission.
+func serializeUint64(value uint64) []byte {
+	bs := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bs, value)
+	return bs
+}
+
+// deserializeUint64 deserializes  the given bytes to uint64.
+func deserializeUint64(bs []byte) uint64 {
+	return binary.LittleEndian.Uint64(bs)
+}

--- a/properties/serialization_test.go
+++ b/properties/serialization_test.go
@@ -1,0 +1,213 @@
+package properties
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerializeBool(t *testing.T) {
+	tests := []struct {
+		input    bool
+		expected []byte
+	}{
+		{true, []byte{1}},
+		{false, []byte{0}},
+	}
+
+	for _, test := range tests {
+		result := serializeBool(test.input)
+		require.Equal(t, test.expected, result)
+	}
+}
+
+func TestDeserializeBool(t *testing.T) {
+	tests := []struct {
+		input    []byte
+		expected bool
+		err      error
+	}{
+		{[]byte{1}, true, nil},
+		{[]byte{0}, false, nil},
+		{[]byte{}, false, nil},
+		{[]byte{1, 0}, false, fmt.Errorf("invalid byte slice length for boolean deserialization")},
+	}
+
+	for _, test := range tests {
+		result, err := deserializeBool(test.input)
+		require.Equal(t, test.expected, result)
+
+		if test.err != nil {
+			require.EqualError(t, err, test.err.Error())
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}
+
+func TestSerializeAndDeserializeByteSliceMap(t *testing.T) {
+	tests := []struct {
+		input map[string][]byte
+	}{
+		{
+			map[string][]byte{
+				"key1": []byte("value1"),
+				"key2": []byte("value2"),
+			},
+		},
+		{
+			map[string][]byte{
+				"hello": []byte("world"),
+				"foo":   []byte("bar"),
+			},
+		},
+		{
+			map[string][]byte{},
+		},
+	}
+
+	for _, test := range tests {
+		serialized := serializeByteSliceMap(test.input)
+		deserialized := deserializeByteSliceMap(serialized)
+		require.Equal(t, test.input, deserialized)
+	}
+}
+
+func TestSerializeAndDeserializeByteSliceSlice(t *testing.T) {
+	tests := []struct {
+		input [][]byte
+	}{
+		{
+			[][]byte{
+				[]byte("slice1"),
+				[]byte("slice2"),
+			},
+		},
+		{
+			[][]byte{
+				[]byte("hello"),
+				[]byte("world"),
+				[]byte("foo"),
+				[]byte("bar"),
+			},
+		},
+		{
+			[][]byte{},
+		},
+	}
+
+	for _, test := range tests {
+		serialized := serializeByteSliceSlice(test.input)
+		deserialized := deserializeByteSliceSlice(serialized)
+		require.Equal(t, test.input, deserialized)
+	}
+}
+
+func TestSerializeAndDeserializeFloat64(t *testing.T) {
+	tests := []struct {
+		input float64
+	}{
+		{input: 123.456},
+		{input: 0.0},
+		{input: -987.654},
+		{input: math.Pi},
+		{input: math.MaxFloat64},
+		{input: math.SmallestNonzeroFloat64},
+	}
+
+	for _, test := range tests {
+		serialized := serializeFloat64(test.input)
+		deserialized := deserializeFloat64(serialized)
+		require.Equal(t, test.input, deserialized)
+	}
+}
+
+func TestSerializeAndDeserializeProtoStringSlice(t *testing.T) {
+	tests := []struct {
+		input []string
+	}{
+		{input: []string{"hello", "world"}},
+		{input: []string{"envoy.formatter.metadata", "envoy.formatter", "envoy.extensions.formatter.metadata.v3.Metadata"}},
+		{input: []string{"a", "ab", "abc", "abcd"}},
+		{input: []string{}},
+		{input: []string{"", "empty", ""}},
+	}
+
+	for _, test := range tests {
+		serialized := serializeProtoStringSlice(test.input)
+		deserialized := deserializeProtoStringSlice(serialized)
+		require.Equal(t, test.input, deserialized)
+	}
+}
+
+func TestSerializeAndDeserializeStringMap(t *testing.T) {
+	tests := []struct {
+		input map[string]string
+	}{
+		{input: map[string]string{"hello": "world", "foo": "bar"}},
+		{input: map[string]string{"key": "value"}},
+		{input: map[string]string{}},
+		{input: map[string]string{"empty": "", "": "empty"}},
+	}
+
+	for _, test := range tests {
+		serialized := serializeStringMap(test.input)
+		deserialized := deserializeStringMap(serialized)
+		require.Equal(t, test.input, deserialized)
+	}
+}
+
+func TestSerializeAndDeserializeStringSlice(t *testing.T) {
+	tests := []struct {
+		input []string
+	}{
+		{input: []string{"hello", "world", "foo", "bar"}},
+		{input: []string{"key", "value"}},
+		{input: []string{}},
+		{input: []string{"", "empty", ""}},
+	}
+
+	for _, test := range tests {
+		serialized := serializeStringSlice(test.input)
+		deserialized := deserializeStringSlice(serialized)
+		require.Equal(t, test.input, deserialized)
+	}
+}
+
+func TestSerializeAndDeserializeTimestamp(t *testing.T) {
+	tests := []struct {
+		input time.Time
+	}{
+		{input: time.Now().UTC()},
+		{input: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{input: time.Date(1990, 5, 15, 5, 5, 5, 5, time.UTC)},
+	}
+
+	for _, test := range tests {
+		serialized := serializeTimestamp(test.input)
+		deserialized := deserializeTimestamp(serialized)
+		if !test.input.Equal(deserialized) {
+			t.Errorf("Expected %v, got %v", test.input, deserialized)
+		}
+	}
+}
+
+func TestSerializeAndDeserializeUint64(t *testing.T) {
+	tests := []struct {
+		input uint64
+	}{
+		{input: 1234567890},
+		{input: 0},
+		{input: 9876543210},
+		{input: 18446744073709551615},
+	}
+
+	for _, test := range tests {
+		serialized := serializeUint64(test.input)
+		deserialized := deserializeUint64(serialized)
+		require.Equal(t, test.input, deserialized)
+	}
+}

--- a/properties/types.go
+++ b/properties/types.go
@@ -1,0 +1,123 @@
+package properties
+
+import "fmt"
+
+// Identifies the direction of the traffic relative to the local Envoy
+//
+// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#enum-config-core-v3-trafficdirection
+type EnvoyTrafficDirection int
+
+const (
+	// ⁣Default option is unspecified
+	Unspecified EnvoyTrafficDirection = iota
+	// The transport is used for incoming traffic
+	Inbound
+	// ⁣The transport is used for outgoing traffic
+	Outbound
+)
+
+func (t EnvoyTrafficDirection) String() string {
+	switch t {
+	case Unspecified:
+		return "UNSPECIFIED"
+	case Inbound:
+		return "INBOUND"
+	case Outbound:
+		return "OUTBOUND"
+	}
+	return "UNSPECIFIED"
+}
+
+// Identifies location of where either Envoy runs or where upstream hosts run
+//
+// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#config-core-v3-locality
+type EnvoyLocality struct {
+	Region  string
+	Zone    string
+	Subzone string
+}
+
+// Version and identification for an Envoy extension
+//
+// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#config-core-v3-extension
+type EnvoyExtension struct {
+	Name     string
+	Category string
+	TypeUrls []string
+}
+
+// Metadata provides additional inputs to filters based on matched listeners,
+// filter chains, routes and endpoints. It is structured as a map, usually from
+// filter name (in reverse DNS format) to metadata specific to the filter. Metadata
+// key-values for a filter are merged as connection and request handling occurs,
+// with later values for the same key overriding earlier values
+//
+// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#config-core-v3-metadata
+type IstioFilterMetadata struct {
+	Config   string
+	Services []IstioService
+}
+
+type IstioService struct {
+	Host      string
+	Name      string
+	Namespace string
+}
+
+// Proxy stats name matchers for stats creation. Note this is in addition to the minimum Envoy stats that
+// Istio generates by default
+//
+// https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig-ProxyStatsMatcher
+type IstioProxyStatsMatcher struct {
+	InclusionPrefixes []string
+	InclusionRegexps  []string
+	InclusionSuffixes []string
+}
+
+// TrafficInterceptionMode indicates how traffic to/from the workload is captured and sent to Envoy. This
+// should not be confused with the CaptureMode in the API that indicates how the user wants traffic to be
+// intercepted for the listener. TrafficInterceptionMode is always derived from the Proxy metadata.
+//
+// https://pkg.go.dev/istio.io/istio/pilot/pkg/model#TrafficInterceptionMode
+type IstioTrafficInterceptionMode int
+
+const (
+	// InterceptionNone indicates that the workload is not using IPtables for traffic interception
+	None IstioTrafficInterceptionMode = iota
+	// InterceptionTproxy implies traffic intercepted by IPtables with TPROXY mode
+	Tproxy
+	// InterceptionRedirect implies traffic intercepted by IPtables with REDIRECT mode. This is our default mode
+	Redirect
+)
+
+// String converts the IstioTrafficInterceptionMode enum value to its corresponding string representation.
+// It returns "NONE" for None, "TPROXY" for Tproxy, and "REDIRECT" for Redirect.
+// If the enum value doesn't match any of the predefined values, it defaults to "REDIRECT".
+func (t IstioTrafficInterceptionMode) String() string {
+	switch t {
+	case None:
+		return "NONE"
+	case Tproxy:
+		return "TPROXY"
+	case Redirect:
+		return "REDIRECT"
+	}
+	return "REDIRECT"
+}
+
+// ParseIstioTrafficInterceptionMode converts a string representation of IstioTrafficInterceptionMode to
+// its corresponding enum value. It returns None for "NONE", Tproxy for "TPROXY", and Redirect for "REDIRECT".
+// If the provided string doesn't match any of the predefined values, it returns an error and the default
+// value Redirect.
+func ParseIstioTrafficInterceptionMode(s string) (IstioTrafficInterceptionMode, error) {
+	switch s {
+	case "NONE":
+		return None, nil
+	case "TPROXY":
+		return Tproxy, nil
+	case "REDIRECT":
+		return Redirect, nil
+	default:
+		return Redirect, fmt.Errorf("invalid IstioTrafficInterceptionMode: %s", s)
+	}
+}

--- a/properties/types.go
+++ b/properties/types.go
@@ -16,6 +16,9 @@ const (
 	Outbound
 )
 
+// String converts the EnvoyTrafficDirection enum value to its corresponding string representation.
+// It returns "UNSPECIFIED" for Unspecified, "INBOUND" for Inbound, and "OUTBOUND" for Outbound.
+// If the enum value doesn't match any of the predefined values, it defaults to "UNSPECIFIED".
 func (t EnvoyTrafficDirection) String() string {
 	switch t {
 	case Unspecified:

--- a/properties/types.go
+++ b/properties/types.go
@@ -2,17 +2,17 @@ package properties
 
 import "fmt"
 
-// Identifies the direction of the traffic relative to the local Envoy
+// EnvoyTrafficDirection identifies the direction of the traffic relative to the local Envoy.
 //
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#enum-config-core-v3-trafficdirection
 type EnvoyTrafficDirection int
 
 const (
-	// ⁣Default option is unspecified
+	// Unspecified means that the direction is not specified.
 	Unspecified EnvoyTrafficDirection = iota
-	// The transport is used for incoming traffic
+	// Inbound means that the transport is used for incoming traffic.
 	Inbound
-	// ⁣The transport is used for outgoing traffic
+	// Outbound means that the transport is used for outgoing traffic.
 	Outbound
 )
 
@@ -28,7 +28,7 @@ func (t EnvoyTrafficDirection) String() string {
 	return "UNSPECIFIED"
 }
 
-// Identifies location of where either Envoy runs or where upstream hosts run
+// EnvoyLocality identifies location of where either Envoy runs or where upstream hosts run.
 //
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#config-core-v3-locality
 type EnvoyLocality struct {
@@ -37,7 +37,7 @@ type EnvoyLocality struct {
 	Subzone string
 }
 
-// Version and identification for an Envoy extension
+// EnvoyExtension holds version and identification for an Envoy extension.
 //
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#config-core-v3-extension
 type EnvoyExtension struct {
@@ -46,11 +46,11 @@ type EnvoyExtension struct {
 	TypeUrls []string
 }
 
-// Metadata provides additional inputs to filters based on matched listeners,
+// IstioFilterMetadata provides additional inputs to filters based on matched listeners,
 // filter chains, routes and endpoints. It is structured as a map, usually from
 // filter name (in reverse DNS format) to metadata specific to the filter. Metadata
 // key-values for a filter are merged as connection and request handling occurs,
-// with later values for the same key overriding earlier values
+// with later values for the same key overriding earlier values.
 //
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#config-core-v3-metadata
 type IstioFilterMetadata struct {
@@ -58,14 +58,15 @@ type IstioFilterMetadata struct {
 	Services []IstioService
 }
 
+// IstioService holds information of the host, name and namespace of an Istio Service.
 type IstioService struct {
 	Host      string
 	Name      string
 	Namespace string
 }
 
-// Proxy stats name matchers for stats creation. Note this is in addition to the minimum Envoy stats that
-// Istio generates by default
+// IstioProxyStatsMatcher holds proxy stats name matches for stats creation. Note this is in addition to the minimum Envoy stats that
+// Istio generates by default.
 //
 // https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig-ProxyStatsMatcher
 type IstioProxyStatsMatcher struct {
@@ -74,19 +75,19 @@ type IstioProxyStatsMatcher struct {
 	InclusionSuffixes []string
 }
 
-// TrafficInterceptionMode indicates how traffic to/from the workload is captured and sent to Envoy. This
+// IstioTrafficInterceptionMode indicates how traffic to/from the workload is captured and sent to Envoy. This
 // should not be confused with the CaptureMode in the API that indicates how the user wants traffic to be
-// intercepted for the listener. TrafficInterceptionMode is always derived from the Proxy metadata.
+// intercepted for the listener. IstioTrafficInterceptionMode is always derived from the Proxy metadata.
 //
 // https://pkg.go.dev/istio.io/istio/pilot/pkg/model#TrafficInterceptionMode
 type IstioTrafficInterceptionMode int
 
 const (
-	// InterceptionNone indicates that the workload is not using IPtables for traffic interception
+	// None indicates that the workload is not using IPtables for traffic interception.
 	None IstioTrafficInterceptionMode = iota
-	// InterceptionTproxy implies traffic intercepted by IPtables with TPROXY mode
+	// Tproxy implies traffic intercepted by IPtables with TPROXY mode.
 	Tproxy
-	// InterceptionRedirect implies traffic intercepted by IPtables with REDIRECT mode. This is our default mode
+	// Redirect implies traffic intercepted by IPtables with REDIRECT mode. This is our default mode.
 	Redirect
 )
 

--- a/properties/types_test.go
+++ b/properties/types_test.go
@@ -1,0 +1,66 @@
+package properties
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvoyTrafficDirectionString(t *testing.T) {
+	tests := []struct {
+		input    EnvoyTrafficDirection
+		expected string
+	}{
+		{Unspecified, "UNSPECIFIED"},
+		{Inbound, "INBOUND"},
+		{Outbound, "OUTBOUND"},
+		{EnvoyTrafficDirection(9999), "UNSPECIFIED"},
+	}
+
+	for _, test := range tests {
+		result := test.input.String()
+		require.Equal(t, test.expected, result)
+	}
+}
+
+func TestIstioTrafficInterceptionModeString(t *testing.T) {
+	tests := []struct {
+		input    IstioTrafficInterceptionMode
+		expected string
+	}{
+		{None, "NONE"},
+		{Tproxy, "TPROXY"},
+		{Redirect, "REDIRECT"},
+		{IstioTrafficInterceptionMode(9999), "REDIRECT"},
+	}
+
+	for _, test := range tests {
+		result := test.input.String()
+		require.Equal(t, test.expected, result)
+	}
+}
+
+func TestParseIstioTrafficInterceptionMode(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected IstioTrafficInterceptionMode
+		err      error
+	}{
+		{"NONE", None, nil},
+		{"TPROXY", Tproxy, nil},
+		{"REDIRECT", Redirect, nil},
+		{"INVALID", Redirect, fmt.Errorf("invalid IstioTrafficInterceptionMode: INVALID")},
+	}
+
+	for _, test := range tests {
+		result, err := ParseIstioTrafficInterceptionMode(test.input)
+		require.Equal(t, test.expected, result)
+
+		if test.err != nil {
+			require.EqualError(t, err, test.err.Error())
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}

--- a/properties/upstream.go
+++ b/properties/upstream.go
@@ -1,0 +1,135 @@
+package properties
+
+// This file hosts helper functions to retrieve upstream-related properties as described in:
+// https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#upstream-attributes
+
+var (
+	upstreamAddress                     = []string{"upstream", "address"}
+	upstreamPort                        = []string{"upstream", "port"}
+	upstreamTlsVersion                  = []string{"upstream", "tls_version"}
+	upstreamSubjectLocalCertificate     = []string{"upstream", "subject_local_certificate"}
+	upstreamSubjectPeerCertificate      = []string{"upstream", "subject_peer_certificate"}
+	upstreamDnsSanLocalCertificate      = []string{"upstream", "dns_san_local_certificate"}
+	upstreamDnsSanPeerCertificate       = []string{"upstream", "dns_san_peer_certificate"}
+	upstreamUriSanLocalCertificate      = []string{"upstream", "uri_san_local_certificate"}
+	upstreamUriSanPeerCertificate       = []string{"upstream", "uri_san_peer_certificate"}
+	upstreamSha256PeerCertificateDigest = []string{"upstream", "sha256_peer_certificate_digest"}
+	upstreamLocalAddress                = []string{"upstream", "local_address"}
+	upstreamTransportFailureReason      = []string{"upstream", "transport_failure_reason"}
+)
+
+// GetUpstreamAddress returns the upstream connection remote address.
+func GetUpstreamAddress() (string, error) {
+	result, err := getPropertyString(upstreamAddress)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetUpstreamPort returns the upstream connection remote port.
+func GetUpstreamPort() (uint64, error) {
+	result, err := getPropertyUint64(upstreamPort)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+// GetUpstreamTlsVersion returns the TLS version of the upstream TLS connection.
+func GetUpstreamTlsVersion() (string, error) {
+	result, err := getPropertyString(upstreamTlsVersion)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetUpstreamSubjectLocalCertificate returns the subject field of the local
+// certificate in the upstream TLS connection.
+func GetUpstreamSubjectLocalCertificate() (string, error) {
+	result, err := getPropertyString(upstreamSubjectLocalCertificate)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetUpstreamSubjectPeerCertificate returns the subject field of the peer
+// certificate in the upstream TLS connection.
+func GetUpstreamSubjectPeerCertificate() (string, error) {
+	result, err := getPropertyString(upstreamSubjectPeerCertificate)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetUpstreamDnsSanLocalCertificate returns the first DNS entry in the SAN
+// field of the local certificate in the upstream TLS connection.
+func GetUpstreamDnsSanLocalCertificate() (string, error) {
+	result, err := getPropertyString(upstreamDnsSanLocalCertificate)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetUpstreamDnsSanPeerCertificate returns the first DNS entry in the SAN
+// field of the peer certificate in the upstream TLS connection.
+func GetUpstreamDnsSanPeerCertificate() (string, error) {
+	result, err := getPropertyString(upstreamDnsSanPeerCertificate)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetUpstreamUriSanLocalCertificate returns the first URI entry in the SAN
+// field of the local certificate in the upstream TLS connection.
+func GetUpstreamUriSanLocalCertificate() (string, error) {
+	result, err := getPropertyString(upstreamUriSanLocalCertificate)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetUpstreamUriSanPeerCertificate returns the first URI entry in the SAN
+// field of the peer certificate in the upstream TLS connection.
+func GetUpstreamUriSanPeerCertificate() (string, error) {
+	result, err := getPropertyString(upstreamUriSanPeerCertificate)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetUpstreamSha256PeerCertificateDigest returns the SHA256 digest of the
+// peer certificate in the upstream TLS connection if present.
+func GetUpstreamSha256PeerCertificateDigest() (string, error) {
+	result, err := getPropertyString(upstreamSha256PeerCertificateDigest)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetUpstreamLocalAddress returns the local address of the upstream connection.
+func GetUpstreamLocalAddress() (string, error) {
+	result, err := getPropertyString(upstreamLocalAddress)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetUpstreamTransportFailureReason returns the upstream transport failure
+// reason e.g. certificate validation failed.
+func GetUpstreamTransportFailureReason() (string, error) {
+	result, err := getPropertyString(upstreamTransportFailureReason)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}

--- a/properties/upstream_test.go
+++ b/properties/upstream_test.go
@@ -1,0 +1,132 @@
+package properties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+)
+
+func TestGetUpstreamAddress(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamAddress, []byte("127.0.0.1"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamAddress()
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1", result)
+}
+
+func TestGetUpstreamPort(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamPort, serializeUint64(8080))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamPort()
+	require.NoError(t, err)
+	require.Equal(t, uint64(8080), result)
+}
+
+func TestGetUpstreamTlsVersion(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamTlsVersion, []byte("TLSv1.3"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamTlsVersion()
+	require.NoError(t, err)
+	require.Equal(t, "TLSv1.3", result)
+}
+
+func TestGetUpstreamSubjectLocalCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamSubjectLocalCertificate,
+		[]byte("CN=example.com,OU=IT,O=example,L=San Francisco,ST=California,C=US"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamSubjectLocalCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "CN=example.com,OU=IT,O=example,L=San Francisco,ST=California,C=US", result)
+}
+
+func TestGetUpstreamSubjectPeerCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamSubjectPeerCertificate,
+		[]byte("CN=example.com,OU=IT,O=example,L=San Francisco,ST=California,C=US"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamSubjectPeerCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "CN=example.com,OU=IT,O=example,L=San Francisco,ST=California,C=US", result)
+}
+
+func TestGetUpstreamDnsSanLocalCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamDnsSanLocalCertificate, []byte("example.com"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamDnsSanLocalCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "example.com", result)
+}
+
+func TestGetUpstreamDnsSanPeerCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamDnsSanPeerCertificate, []byte("example.com"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamDnsSanPeerCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "example.com", result)
+}
+
+func TestGetUpstreamUriSanLocalCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamUriSanLocalCertificate, []byte("example.com"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamUriSanLocalCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "example.com", result)
+}
+
+func TestGetUpstreamUriSanPeerCertificate(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamUriSanPeerCertificate, []byte("example.com"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamUriSanPeerCertificate()
+	require.NoError(t, err)
+	require.Equal(t, "example.com", result)
+}
+
+func TestGetUpstreamSha256PeerCertificateDigest(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamSha256PeerCertificateDigest,
+		[]byte("b714f3d6f83efc2fddf80b8feda3e3b21b3e27b5"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamSha256PeerCertificateDigest()
+	require.NoError(t, err)
+	require.Equal(t, "b714f3d6f83efc2fddf80b8feda3e3b21b3e27b5", result)
+}
+
+func TestGetUpstreamLocalAddress(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamLocalAddress, []byte("192.168.1.1"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamLocalAddress()
+	require.NoError(t, err)
+	require.Equal(t, "192.168.1.1", result)
+}
+
+func TestGetUpstreamTransportFailureReason(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(upstreamTransportFailureReason, []byte("connection closed"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetUpstreamTransportFailureReason()
+	require.NoError(t, err)
+	require.Equal(t, "connection closed", result)
+}

--- a/properties/util_test.go
+++ b/properties/util_test.go
@@ -1,0 +1,118 @@
+package properties
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+)
+
+func TestGetPropertyBool(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty([]string{"someBoolPath"}, serializeBool(true))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := getPropertyBool([]string{"someBoolPath"})
+	require.NoError(t, err)
+	require.Equal(t, true, result)
+}
+
+func TestGetPropertyByteSliceMap(t *testing.T) {
+	input := map[string][]byte{
+		"key1": []byte("value1"),
+		"key2": []byte("value2"),
+	}
+
+	opt := proxytest.NewEmulatorOption().WithProperty([]string{"someByteSliceMapPath"}, serializeByteSliceMap(input))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := getPropertyByteSliceMap([]string{"someByteSliceMapPath"})
+	require.NoError(t, err)
+	require.Equal(t, input, result)
+}
+
+func TestGetPropertyByteSliceSlice(t *testing.T) {
+	input := [][]byte{
+		[]byte("value1"),
+		[]byte("value2"),
+	}
+
+	opt := proxytest.NewEmulatorOption().WithProperty([]string{"someByteSliceSlicePath"}, serializeByteSliceSlice(input))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := getPropertyByteSliceSlice([]string{"someByteSliceSlicePath"})
+	require.NoError(t, err)
+	require.Equal(t, input, result)
+}
+
+func TestGetPropertyFloat64(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty([]string{"someFloat64Path"}, serializeFloat64(3.14))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := getPropertyFloat64([]string{"someFloat64Path"})
+	require.NoError(t, err)
+	require.Equal(t, 3.14, result)
+}
+
+func TestGetPropertyString(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty([]string{"someStringPath"}, []byte("testString"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := getPropertyString([]string{"someStringPath"})
+	require.NoError(t, err)
+	require.Equal(t, "testString", result)
+}
+
+func TestGetPropertyStringMap(t *testing.T) {
+	input := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	opt := proxytest.NewEmulatorOption().WithProperty([]string{"someStringMapPath"}, serializeStringMap(input))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := getPropertyStringMap([]string{"someStringMapPath"})
+	require.NoError(t, err)
+	require.Equal(t, input, result)
+}
+
+func TestGetPropertyStringSlice(t *testing.T) {
+	input := []string{"value1", "value2"}
+
+	opt := proxytest.NewEmulatorOption().WithProperty([]string{"someStringSlicePath"}, serializeStringSlice(input))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := getPropertyStringSlice([]string{"someStringSlicePath"})
+	require.NoError(t, err)
+	require.Equal(t, input, result)
+}
+
+func TestGetPropertyTimestamp(t *testing.T) {
+	now := time.Now().UTC()
+
+	opt := proxytest.NewEmulatorOption().WithProperty([]string{"someTimestampPath"}, serializeTimestamp(now))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := getPropertyTimestamp([]string{"someTimestampPath"})
+	require.NoError(t, err)
+	require.Equal(t, now, result)
+}
+
+func TestGetPropertyUint64(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty([]string{"someUint64Path"}, serializeUint64(12345))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := getPropertyUint64([]string{"someUint64Path"})
+	require.NoError(t, err)
+	require.Equal(t, uint64(12345), result)
+}

--- a/properties/util_test.go
+++ b/properties/util_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
 )
 

--- a/properties/wasm.go
+++ b/properties/wasm.go
@@ -1,0 +1,288 @@
+package properties
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+)
+
+// This file hosts helper functions to retrieve wasm-related properties as described in:
+// https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#wasm-attributes
+
+var (
+	pluginName                = []string{"plugin_name"}
+	pluginRootId              = []string{"plugin_root_id"}
+	pluginVmId                = []string{"plugin_vm_id"}
+	clusterName               = []string{"cluster_name"}
+	routeName                 = []string{"route_name"}
+	listenerDirection         = []string{"listener_direction"}
+	nodeId                    = []string{"node", "id"}
+	nodeCluster               = []string{"node", "cluster"}
+	nodeDynamicParams         = []string{"node", "dynamic_parameters", "params"}
+	nodeLocalityRegion        = []string{"node", "locality", "region"}
+	nodeLocalityZone          = []string{"node", "locality", "zone"}
+	nodeLocalitySubzone       = []string{"node", "locality", "subzone"}
+	nodeUserAgentName         = []string{"node", "user_agent_name"}
+	nodeUserAgentVersion      = []string{"node", "user_agent_version"}
+	nodeUserAgentBuildVersion = []string{"node", "user_agent_build_version", "metadata"}
+	nodeExtensions            = []string{"node", "extensions"}
+	nodeClientFeatures        = []string{"node", "client_features"}
+	nodeListeningAddresses    = []string{"node", "listening_addresses"}
+	clusterMetadata           = []string{"node", "cluster_metadata", "filter_metadata", "istio"}
+	listenerMetadata          = []string{"node", "listener_metadata", "filter_metadata", "istio"}
+	routeMetadata             = []string{"node", "route_metadata", "filter_metadata", "istio"}
+	upstreamHostMetadata      = []string{"node", "upstream_host_metadata", "filter_metadata", "istio"}
+)
+
+// GetPluginName returns the plugin name.
+//
+// This matches <metadata.name>.<metadata.namespace> in an istio WasmPlugin CR.
+func GetPluginName() (string, error) {
+	result, err := getPropertyString(pluginName)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetPluginRootId returns the plugin root id.
+//
+// This matches the <spec.pluginName> in the istio WasmPlugin CR.
+func GetPluginRootId() (string, error) {
+	result, err := getPropertyString(pluginRootId)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetPluginVmId returns the plugin vm id.
+func GetPluginVmId() (string, error) {
+	result, err := getPropertyString(pluginVmId)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetClusterName returns the upstream cluster name.
+//
+// Example value: "outbound|80||httpbin.org".
+func GetClusterName() (string, error) {
+	result, err := getPropertyString(clusterName)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetRouteName returns the route name, only available in the response path (cfr getXdsRouteName()).
+//
+// This matches the <spec.http.name> in the istio VirtualService CR.
+func GetRouteName() (string, error) {
+	result, err := getPropertyString(routeName)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetListenerDirection returns the listener direction.
+//
+// Possible values are:
+//
+//   - UNSPECIFIED: 0 (default option is unspecified)
+//   - INBOUND: 1 (⁣the transport is used for incoming traffic)
+//   - OUTBOUND: 2 (the transport is used for outgoing traffic)
+func GetListenerDirection() (EnvoyTrafficDirection, error) {
+	result, err := getPropertyUint64(listenerDirection)
+	if err != nil {
+		return EnvoyTrafficDirection(Unspecified), err
+	}
+	return EnvoyTrafficDirection(int(result)), nil
+}
+
+// GetNodeId returns the node id, an opaque node identifier for the Envoy node. This also
+// provides the local service node name. It should be set if any of the following features
+// are used: statsd, CDS, and HTTP tracing, either in this message or via --service-node
+//
+// Example value:
+// router~10.244.0.22~istio-ingress-6d78c67d85-qsbtz.istio-ingress~istio-ingress.svc.cluster.local
+func GetNodeId() (string, error) {
+	result, err := getPropertyString(nodeId)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeCluster returns the node cluster, which defines the local service cluster
+// name where envoy is running. Though optional, it should be set if any of the following
+// features are used: statsd, health check cluster verification, runtime override directory,
+// user agent addition, HTTP global rate limiting, CDS, and HTTP tracing, either in this
+// message or via --service-cluster
+//
+// Example value: istio-ingress.istio-ingress
+func GetNodeCluster() (string, error) {
+	result, err := getPropertyString(nodeCluster)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeDynamicParams returns the node dynamic parameters. These may vary at
+// runtime (unlike other fields in this message). For example, the xDS client may have a
+// shared identifier that changes during the lifetime of the xDS client. In Envoy, this
+// would be achieved by updating the dynamic context on the Server::Instance’s LocalInfo
+// context provider. The shard ID dynamic parameter then appears in this field during
+// future discovery requests
+func GetNodeDynamicParams() (string, error) {
+	result, err := getPropertyString(nodeDynamicParams)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeLocality returns the node locality.
+func GetNodeLocality() (EnvoyLocality, error) {
+	result := EnvoyLocality{}
+	var errors []string
+	var successCount int
+
+	region, err := getPropertyString(nodeLocalityRegion)
+	if err != nil {
+		errors = append(errors, err.Error())
+	} else {
+		result.Region = region
+		successCount++
+	}
+
+	zone, err := getPropertyString(nodeLocalityZone)
+	if err != nil {
+		errors = append(errors, err.Error())
+	} else {
+		result.Zone = zone
+		successCount++
+	}
+
+	subzone, err := getPropertyString(nodeLocalitySubzone)
+	if err != nil {
+		errors = append(errors, err.Error())
+	} else {
+		result.Subzone = subzone
+		successCount++
+	}
+
+	if successCount == 0 {
+		return result, fmt.Errorf(strings.Join(errors, "; "))
+	}
+
+	return result, nil
+}
+
+// GetNodeUserAgentName returns the node user agent name.
+//
+// Example: “envoy” or “grpc”.
+func GetNodeUserAgentName() (string, error) {
+	result, err := getPropertyString(nodeUserAgentName)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeUserAgentVersion returns the node user agent version.
+//
+// Example “1.12.2” or “abcd1234”, or “SpecialEnvoyBuild”.
+func GetNodeUserAgentVersion() (string, error) {
+	result, err := getPropertyString(nodeUserAgentVersion)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeUserAgentBuildVersion returns the node user agent build version.
+func GetNodeUserAgentBuildVersion() (string, error) {
+	result, err := getPropertyString(nodeUserAgentBuildVersion)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetNodeExtensions returns the node extensions.
+func GetNodeExtensions() ([]EnvoyExtension, error) {
+	result := make([]EnvoyExtension, 0)
+	extensionsRawSlice, err := getPropertyByteSliceSlice(nodeExtensions)
+	if err != nil {
+		return []EnvoyExtension{}, err
+	}
+
+	for _, extensionRawSlice := range extensionsRawSlice {
+		if extensionRawSlice == nil {
+			continue
+		}
+		extensionStringSlice := deserializeProtoStringSlice(extensionRawSlice)
+		extension := EnvoyExtension{}
+
+		if len(extensionStringSlice) > 0 {
+			extension.Name = string(extensionStringSlice[0])
+		}
+		if len(extensionStringSlice) > 1 {
+			extension.Category = string(extensionStringSlice[1])
+		}
+		if len(extensionStringSlice) > 2 {
+			extenstionTypeUrls := []string{}
+			extenstionTypeUrls = append(extenstionTypeUrls, extensionStringSlice[2:]...)
+			extension.TypeUrls = extenstionTypeUrls
+		}
+
+		result = append(result, extension)
+	}
+
+	return result, nil
+}
+
+// GetNodeClientFeatures returns the node client features. These are well known features
+// described in the Envoy API repository for a given major version of an API. Client
+// features use reverse DNS naming scheme, for example "com.acme.feature".
+func GetNodeClientFeatures() ([]string, error) {
+	result, err := proxywasm.GetProperty(nodeClientFeatures)
+	if err != nil {
+		return []string{}, err
+	}
+	return deserializeProtoStringSlice(result), nil
+}
+
+// GetNodeListeningAddresses returns the node listening addresses.
+func GetNodeListeningAddresses() ([]string, error) {
+	result, err := getPropertyStringSlice(nodeListeningAddresses)
+	if err != nil {
+		return []string{}, err
+	}
+	return result, nil
+}
+
+// GetClusterMetadata returns the cluster metadata.
+func GetClusterMetadata() (IstioFilterMetadata, error) {
+	return getIstioFilterMetadata(clusterMetadata)
+}
+
+// GetListenerMetadata returns the listener metadata.
+func GetListenerMetadata() (IstioFilterMetadata, error) {
+	return getIstioFilterMetadata(listenerMetadata)
+}
+
+// GetRouteMetadata returns the route metadata.
+func GetRouteMetadata() (IstioFilterMetadata, error) {
+	return getIstioFilterMetadata(routeMetadata)
+}
+
+// GetUpstreamHostMetadata returns the upstream host metadata.
+func GetUpstreamHostMetadata() (IstioFilterMetadata, error) {
+	return getIstioFilterMetadata(upstreamHostMetadata)
+}

--- a/properties/wasm_test.go
+++ b/properties/wasm_test.go
@@ -1,0 +1,190 @@
+package properties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+)
+
+func TestGetPluginName(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(pluginName, []byte("istio-ingress.print-properties"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetPluginName()
+	require.NoError(t, err)
+	require.Equal(t, "istio-ingress.print-properties", result)
+}
+
+func TestGetPluginRootId(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(pluginRootId, []byte("print-properties"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetPluginRootId()
+	require.NoError(t, err)
+	require.Equal(t, "print-properties", result)
+}
+
+func TestGetPluginVmId(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(pluginVmId, []byte("plugin-vm-id-value"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetPluginVmId()
+	require.NoError(t, err)
+	require.Equal(t, "plugin-vm-id-value", result)
+}
+
+func TestGetClusterName(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(clusterName, []byte("outbound|80||httpbin.org"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetClusterName()
+	require.NoError(t, err)
+	require.Equal(t, "outbound|80||httpbin.org", result)
+}
+
+func TestGetRouteName(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(routeName, []byte("route-name-value"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetRouteName()
+	require.NoError(t, err)
+	require.Equal(t, "route-name-value", result)
+}
+
+func TestGetListenerDirection(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          uint64
+		expectedResult EnvoyTrafficDirection
+	}{
+		{
+			name:           "Unspecified",
+			input:          0,
+			expectedResult: Unspecified,
+		},
+		{
+			name:           "Inbound",
+			input:          1,
+			expectedResult: Inbound,
+		},
+		{
+			name:           "Outound",
+			input:          2,
+			expectedResult: Outbound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := proxytest.NewEmulatorOption().WithProperty(listenerDirection, serializeUint64(tt.input))
+			_, reset := proxytest.NewHostEmulator(opt)
+			defer reset()
+
+			result, err := GetListenerDirection()
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func TestGetNodeId(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeId, []byte("router~10.244.0.22~istio-ingress-6d78c67d85-qsbtz.istio-ingress~istio-ingress.svc.cluster.local"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeId()
+	require.NoError(t, err)
+	require.Equal(t, "router~10.244.0.22~istio-ingress-6d78c67d85-qsbtz.istio-ingress~istio-ingress.svc.cluster.local", result)
+}
+
+func TestGetNodeCluster(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeCluster, []byte("istio-ingress.istio-ingress"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeCluster()
+	require.NoError(t, err)
+	require.Equal(t, "istio-ingress.istio-ingress", result)
+}
+
+func TestGetNodeDynamicParams(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeDynamicParams, []byte("dynamic-params-value"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeDynamicParams()
+	require.NoError(t, err)
+	require.Equal(t, "dynamic-params-value", result)
+}
+
+func TestGetNodeLocality(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().
+		WithProperty(nodeLocalityRegion, []byte("region-value")).
+		WithProperty(nodeLocalityZone, []byte("zone-value")).
+		WithProperty(nodeLocalitySubzone, []byte("subzone-value"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeLocality()
+	require.NoError(t, err)
+	require.Equal(t, "region-value", result.Region)
+	require.Equal(t, "zone-value", result.Zone)
+	require.Equal(t, "subzone-value", result.Subzone)
+}
+
+func TestGetNodeUserAgentName(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeUserAgentName, []byte("envoy"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeUserAgentName()
+	require.NoError(t, err)
+	require.Equal(t, "envoy", result)
+}
+
+func TestGetNodeUserAgentVersion(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeUserAgentVersion, []byte("1.12.2"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeUserAgentVersion()
+	require.NoError(t, err)
+	require.Equal(t, "1.12.2", result)
+}
+
+func TestGetNodeUserAgentBuildVersion(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeUserAgentBuildVersion, []byte("build-version-value"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeUserAgentBuildVersion()
+	require.NoError(t, err)
+	require.Equal(t, "build-version-value", result)
+}
+
+func TestGetNodeClientFeatures(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeClientFeatures, serializeProtoStringSlice([]string{"feature1-data", "feature2-data"}))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeClientFeatures()
+	require.NoError(t, err)
+	require.Equal(t, []string{"feature1-data", "feature2-data"}, result)
+}
+
+func TestGetNodeListeningAddresses(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(nodeListeningAddresses, serializeStringSlice([]string{"192.168.0.10", "10.0.0.20"}))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetNodeListeningAddresses()
+	require.NoError(t, err)
+	require.Equal(t, []string{"192.168.0.10", "10.0.0.20"}, result)
+}

--- a/properties/xsd.go
+++ b/properties/xsd.go
@@ -1,0 +1,59 @@
+package properties
+
+// This file hosts helper functions to retrieve xsd-configuration-related properties as described in:
+// https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#configuration-attributes
+
+var (
+	xdsClusterName             = []string{"xds", "cluster_name"}
+	xdsClusterMetadata         = []string{"xds", "cluster_metadata", "filter_metadata", "istio"}
+	xdsRouteName               = []string{"xds", "route_name"}
+	xdsRouteMetadata           = []string{"xds", "route_metadata", "filter_metadata", "istio"}
+	xdsUpstreamHostMetadata    = []string{"xds", "upstream_host_metadata", "filter_metadata", "istio"}
+	xdsListenerFilterChainName = []string{"xds", "filter_chain_name"}
+)
+
+// GetXdsClusterName returns the upstream cluster name.
+//
+// Example value: "outbound|80||httpbin.org".
+func GetXdsClusterName() (string, error) {
+	result, err := getPropertyString(xdsClusterName)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetXdsClusterMetadata returns the upstream cluster metadata.
+func GetXdsClusterMetadata() (IstioFilterMetadata, error) {
+	return getIstioFilterMetadata(xdsClusterMetadata)
+}
+
+// GetXdsRouteName returns the upstream route name (available in both
+// the request response path, cfr getRouteName()). This matches the
+// <spec.http.name> in an istio VirtualService CR.
+func GetXdsRouteName() (string, error) {
+	result, err := getPropertyString(xdsRouteName)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// GetXdsRouteMetadata returns the upstream route metadata.
+func GetXdsRouteMetadata() (IstioFilterMetadata, error) {
+	return getIstioFilterMetadata(xdsRouteMetadata)
+}
+
+// GetXdsUpstreamHostMetadata returns the upstream host metadata.
+func GetXdsUpstreamHostMetadata() (IstioFilterMetadata, error) {
+	return getIstioFilterMetadata(xdsUpstreamHostMetadata)
+}
+
+// GetXdsListenerFilterChainName returns the listener filter chain name.
+func GetXdsListenerFilterChainName() (string, error) {
+	result, err := getPropertyString(xdsListenerFilterChainName)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}

--- a/properties/xsd_test.go
+++ b/properties/xsd_test.go
@@ -1,0 +1,38 @@
+package properties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+)
+
+func TestGetXdsClusterName(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(xdsClusterName, []byte("outbound|80||httpbin.org"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetXdsClusterName()
+	require.NoError(t, err)
+	require.Equal(t, "outbound|80||httpbin.org", result)
+}
+
+func TestGetXdsRouteName(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(xdsRouteName, []byte("routename"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetXdsRouteName()
+	require.NoError(t, err)
+	require.Equal(t, "routename", result)
+}
+func TestGetXdsListenerFilterChainName(t *testing.T) {
+	opt := proxytest.NewEmulatorOption().WithProperty(xdsListenerFilterChainName, []byte("mychain"))
+	_, reset := proxytest.NewHostEmulator(opt)
+	defer reset()
+
+	result, err := GetXdsListenerFilterChainName()
+	require.NoError(t, err)
+	require.Equal(t, "mychain", result)
+}


### PR DESCRIPTION
Ported the work done in WASM plugins to expose the properties API.

-  Added all of the Getters in separate files
-  Added marshaling and marshaling functions in `serialization.go`
-  Added Istio and Envoy specific types in `types.go`
-  Added GetProperty<Type> functions in `utils.go`
-  Ported all documentation over
-  Adopted unit test input data reflecting real data (from an Istio based setup) 

TBD with @mathetake @jcchavezs @nacx 

- The `marshaling` and `unmarshaling` functions should not be exclusive to `properties` api, as they are essential for the shared data API between different plugins as well
- Some consideration might need to be taken on `Envoy` vs `Istio` specific logic, although this is now already cleanly separated in different files