### PR TITLE
properties: ensures enum naming consistency

### DIFF
--- a/properties/pilot.go
+++ b/properties/pilot.go
@@ -75,11 +75,11 @@ func GetNodeMetaInstanceIps() (string, error) {
 func GetNodeMetaInterceptionMode() (IstioTrafficInterceptionMode, error) {
 	result, err := getPropertyString(nodeMetaInterceptionMode)
 	if err != nil {
-		return Redirect, err
+		return IstioTrafficInterceptionModeRedirect, err
 	}
 	mode, err := ParseIstioTrafficInterceptionMode(result)
 	if err != nil {
-		return Redirect, err
+		return IstioTrafficInterceptionModeRedirect, err
 	}
 	return mode, nil
 }

--- a/properties/pilot_test.go
+++ b/properties/pilot_test.go
@@ -118,25 +118,25 @@ func TestGetNodeMetaInterceptionMode(t *testing.T) {
 		{
 			name:           "Valid TPROXY mode",
 			propertyValue:  []byte("TPROXY"),
-			expectedResult: Tproxy,
+			expectedResult: IstioTrafficInterceptionModeTproxy,
 			expectedError:  nil,
 		},
 		{
 			name:           "Valid REDIRECT mode",
 			propertyValue:  []byte("REDIRECT"),
-			expectedResult: Redirect,
+			expectedResult: IstioTrafficInterceptionModeRedirect,
 			expectedError:  nil,
 		},
 		{
 			name:           "Valid NONE mode",
 			propertyValue:  []byte("NONE"),
-			expectedResult: None,
+			expectedResult: IstioTrafficInterceptionModeNone,
 			expectedError:  nil,
 		},
 		{
 			name:           "Invalid mode",
 			propertyValue:  []byte("INVALID_MODE"),
-			expectedResult: Redirect,
+			expectedResult: IstioTrafficInterceptionModeRedirect,
 			expectedError:  fmt.Errorf("invalid IstioTrafficInterceptionMode: INVALID_MODE"),
 		},
 	}

--- a/properties/types.go
+++ b/properties/types.go
@@ -8,12 +8,12 @@ import "fmt"
 type EnvoyTrafficDirection int
 
 const (
-	// Unspecified means that the direction is not specified.
-	Unspecified EnvoyTrafficDirection = iota
-	// Inbound means that the transport is used for incoming traffic.
-	Inbound
-	// Outbound means that the transport is used for outgoing traffic.
-	Outbound
+	// EnvoyTrafficDirectionUnspecified means that the direction is not specified.
+	EnvoyTrafficDirectionUnspecified EnvoyTrafficDirection = iota
+	// EnvoyTrafficDirectionInbound means that the transport is used for incoming traffic.
+	EnvoyTrafficDirectionInbound
+	// EnvoyTrafficDirectionOutbound means that the transport is used for outgoing traffic.
+	EnvoyTrafficDirectionOutbound
 )
 
 // String converts the EnvoyTrafficDirection enum value to its corresponding string representation.
@@ -21,11 +21,11 @@ const (
 // If the enum value doesn't match any of the predefined values, it defaults to "UNSPECIFIED".
 func (t EnvoyTrafficDirection) String() string {
 	switch t {
-	case Unspecified:
+	case EnvoyTrafficDirectionUnspecified:
 		return "UNSPECIFIED"
-	case Inbound:
+	case EnvoyTrafficDirectionInbound:
 		return "INBOUND"
-	case Outbound:
+	case EnvoyTrafficDirectionOutbound:
 		return "OUTBOUND"
 	}
 	return "UNSPECIFIED"
@@ -86,12 +86,12 @@ type IstioProxyStatsMatcher struct {
 type IstioTrafficInterceptionMode int
 
 const (
-	// None indicates that the workload is not using IPtables for traffic interception.
-	None IstioTrafficInterceptionMode = iota
-	// Tproxy implies traffic intercepted by IPtables with TPROXY mode.
-	Tproxy
-	// Redirect implies traffic intercepted by IPtables with REDIRECT mode. This is our default mode.
-	Redirect
+	// IstioTrafficInterceptionModeNone indicates that the workload is not using IPtables for traffic interception.
+	IstioTrafficInterceptionModeNone IstioTrafficInterceptionMode = iota
+	// IstioTrafficInterceptionModeTproxy implies traffic intercepted by IPtables with TPROXY mode.
+	IstioTrafficInterceptionModeTproxy
+	// IstioTrafficInterceptionModeRedirect implies traffic intercepted by IPtables with REDIRECT mode. This is our default mode.
+	IstioTrafficInterceptionModeRedirect
 )
 
 // String converts the IstioTrafficInterceptionMode enum value to its corresponding string representation.
@@ -99,11 +99,11 @@ const (
 // If the enum value doesn't match any of the predefined values, it defaults to "REDIRECT".
 func (t IstioTrafficInterceptionMode) String() string {
 	switch t {
-	case None:
+	case IstioTrafficInterceptionModeNone:
 		return "NONE"
-	case Tproxy:
+	case IstioTrafficInterceptionModeTproxy:
 		return "TPROXY"
-	case Redirect:
+	case IstioTrafficInterceptionModeRedirect:
 		return "REDIRECT"
 	}
 	return "REDIRECT"
@@ -116,12 +116,12 @@ func (t IstioTrafficInterceptionMode) String() string {
 func ParseIstioTrafficInterceptionMode(s string) (IstioTrafficInterceptionMode, error) {
 	switch s {
 	case "NONE":
-		return None, nil
+		return IstioTrafficInterceptionModeNone, nil
 	case "TPROXY":
-		return Tproxy, nil
+		return IstioTrafficInterceptionModeTproxy, nil
 	case "REDIRECT":
-		return Redirect, nil
+		return IstioTrafficInterceptionModeRedirect, nil
 	default:
-		return Redirect, fmt.Errorf("invalid IstioTrafficInterceptionMode: %s", s)
+		return IstioTrafficInterceptionModeRedirect, fmt.Errorf("invalid IstioTrafficInterceptionMode: %s", s)
 	}
 }

--- a/properties/types_test.go
+++ b/properties/types_test.go
@@ -12,9 +12,9 @@ func TestEnvoyTrafficDirectionString(t *testing.T) {
 		input    EnvoyTrafficDirection
 		expected string
 	}{
-		{Unspecified, "UNSPECIFIED"},
-		{Inbound, "INBOUND"},
-		{Outbound, "OUTBOUND"},
+		{EnvoyTrafficDirectionUnspecified, "UNSPECIFIED"},
+		{EnvoyTrafficDirectionInbound, "INBOUND"},
+		{EnvoyTrafficDirectionOutbound, "OUTBOUND"},
 		{EnvoyTrafficDirection(9999), "UNSPECIFIED"},
 	}
 
@@ -29,9 +29,9 @@ func TestIstioTrafficInterceptionModeString(t *testing.T) {
 		input    IstioTrafficInterceptionMode
 		expected string
 	}{
-		{None, "NONE"},
-		{Tproxy, "TPROXY"},
-		{Redirect, "REDIRECT"},
+		{IstioTrafficInterceptionModeNone, "NONE"},
+		{IstioTrafficInterceptionModeTproxy, "TPROXY"},
+		{IstioTrafficInterceptionModeRedirect, "REDIRECT"},
 		{IstioTrafficInterceptionMode(9999), "REDIRECT"},
 	}
 
@@ -47,10 +47,10 @@ func TestParseIstioTrafficInterceptionMode(t *testing.T) {
 		expected IstioTrafficInterceptionMode
 		err      error
 	}{
-		{"NONE", None, nil},
-		{"TPROXY", Tproxy, nil},
-		{"REDIRECT", Redirect, nil},
-		{"INVALID", Redirect, fmt.Errorf("invalid IstioTrafficInterceptionMode: INVALID")},
+		{"NONE", IstioTrafficInterceptionModeNone, nil},
+		{"TPROXY", IstioTrafficInterceptionModeTproxy, nil},
+		{"REDIRECT", IstioTrafficInterceptionModeRedirect, nil},
+		{"INVALID", IstioTrafficInterceptionModeRedirect, fmt.Errorf("invalid IstioTrafficInterceptionMode: INVALID")},
 	}
 
 	for _, test := range tests {

--- a/properties/wasm.go
+++ b/properties/wasm.go
@@ -78,7 +78,7 @@ func GetRouteName() (string, error) {
 func GetListenerDirection() (EnvoyTrafficDirection, error) {
 	result, err := getPropertyUint64(listenerDirection)
 	if err != nil {
-		return EnvoyTrafficDirection(Unspecified), err
+		return EnvoyTrafficDirectionUnspecified, err
 	}
 	return EnvoyTrafficDirection(int(result)), nil
 }

--- a/properties/wasm_test.go
+++ b/properties/wasm_test.go
@@ -67,17 +67,17 @@ func TestGetListenerDirection(t *testing.T) {
 		{
 			name:           "Unspecified",
 			input:          0,
-			expectedResult: Unspecified,
+			expectedResult: EnvoyTrafficDirectionUnspecified,
 		},
 		{
 			name:           "Inbound",
 			input:          1,
-			expectedResult: Inbound,
+			expectedResult: EnvoyTrafficDirectionInbound,
 		},
 		{
 			name:           "Outound",
 			input:          2,
-			expectedResult: Outbound,
+			expectedResult: EnvoyTrafficDirectionOutbound,
 		},
 	}
 


### PR DESCRIPTION
cc @boeboe 