### PR TITLE
fix: body callbacks return the whole buffered body size

### DIFF
--- a/examples/http_body/main_test.go
+++ b/examples/http_body/main_test.go
@@ -264,7 +264,7 @@ func TestEchoBodyContext_OnHttpRequestBody(t *testing.T) {
 			// Create http context.
 			id := host.InitializeHttpContext()
 
-			for _, frame := range []string{"frame1...", "frame2..."} {
+			for _, frame := range []string{"frame1...", "frame2...", "frame3..."} {
 				// Call OnRequestHeaders without "content-length"
 				action := host.CallOnRequestBody(id, []byte(frame), false /* end of stream */)
 
@@ -282,7 +282,7 @@ func TestEchoBodyContext_OnHttpRequestBody(t *testing.T) {
 			localResponse := host.GetSentLocalResponse(id)
 			require.NotNil(t, localResponse)
 			require.Equal(t, uint32(200), localResponse.StatusCode)
-			require.Equal(t, "frame1...frame2...", string(localResponse.Data))
+			require.Equal(t, "frame1...frame2...frame3...", string(localResponse.Data))
 		})
 	})
 }

--- a/proxywasm/proxytest/http.go
+++ b/proxywasm/proxytest/http.go
@@ -416,7 +416,7 @@ func (h *httpHostEmulator) CallOnRequestBody(contextID uint32, body []byte, endO
 
 	cs.requestBody = append(cs.requestBodyBuffer, body...)
 	cs.action = internal.ProxyOnRequestBody(contextID,
-		len(body), endOfStream)
+		len(cs.requestBody), endOfStream)
 	if cs.action == types.ActionPause {
 		// Buffering requested
 		cs.requestBodyBuffer = cs.requestBody
@@ -435,7 +435,7 @@ func (h *httpHostEmulator) CallOnResponseBody(contextID uint32, body []byte, end
 
 	cs.responseBody = append(cs.responseBodyBuffer, body...)
 	cs.action = internal.ProxyOnResponseBody(contextID,
-		len(body), endOfStream)
+		len(cs.responseBody), endOfStream)
 	if cs.action == types.ActionPause {
 		// Buffering requested
 		cs.responseBodyBuffer = cs.responseBody

--- a/proxywasm/proxytest/http_test.go
+++ b/proxywasm/proxytest/http_test.go
@@ -85,13 +85,15 @@ func TestBodyBuffering(t *testing.T) {
 			name:     "buffered",
 			buffered: true,
 			action:   types.ActionPause,
-			logged:   "11111",
+			// The first chunk has been buffered, therefore it will be retrieved when calling GetHttpRequestBody at the end of stream.
+			logged: "1111122222",
 		},
 		{
 			name:     "unbuffered",
 			buffered: false,
 			action:   types.ActionContinue,
-			logged:   "22222",
+			// The first chunk has not been buffered, therefore it will not be retrieved when calling GetHttpRequestBody at the end of stream.
+			logged: "22222",
 		},
 	}
 


### PR DESCRIPTION
Following https://github.com/tetratelabs/proxy-wasm-go-sdk/issues/414 discussion this PR tries to:
- Fix the emulator: providing to `ProxyOnRequestBody` and `ProxyOnResponseBody` the size of the whole body buffer, not of the individual chunk.
- Clarifies the buffering usage in `http_body` example.
- ~~Adds `http_body_chunk` example showing how to read chunk by chunk while buffering.~~ → See https://github.com/tetratelabs/proxy-wasm-go-sdk/pull/421
- ~~nit: https://github.com/tetratelabs/proxy-wasm-go-sdk/pull/410~~ → See https://github.com/tetratelabs/proxy-wasm-go-sdk/pull/419
- ~~upgrades support for latest envoy and istio/proxyv2~~ → See https://github.com/tetratelabs/proxy-wasm-go-sdk/pull/420

Tentatively closes https://github.com/tetratelabs/proxy-wasm-go-sdk/issues/414.