### PR TITLE
chore: fixes typos

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -241,9 +241,9 @@ func Test_network(t *testing.T) {
 			"upstream data received",
 			"connection complete!",
 			"remote address: 127.0.0.1:",
-			"upsteam cluster matadata location[region]=ap-northeast-1",
-			"upsteam cluster matadata location[cloud_provider]=aws",
-			"upsteam cluster matadata location[az]=ap-northeast-1a",
+			"upstream cluster metadata location[region]=ap-northeast-1",
+			"upstream cluster metadata location[cloud_provider]=aws",
+			"upstream cluster metadata location[az]=ap-northeast-1a",
 		})
 	}, 10*time.Second, 100*time.Millisecond, stdErr.String())
 }

--- a/examples/multiple_dispatches/README.md
+++ b/examples/multiple_dispatches/README.md
@@ -1,6 +1,6 @@
 ## multiple_dispatches
 
-This example dispatches multiple http calls to remote clusters while pausing the original http response processing from the upsteam.
+This example dispatches multiple http calls to remote clusters while pausing the original http response processing from the upstream.
 Once the plugin recieved all the responses to all dispatched calls, it adds an http header to the original http response, and resumes it 
 inside the dispatched callback.
 

--- a/examples/network/main.go
+++ b/examples/network/main.go
@@ -103,7 +103,7 @@ func (ctx *networkContext) OnUpstreamData(dataSize int, endOfStream bool) types.
 
 	for _, metadata := range metadataKeyValues {
 		key, value := metadata[0], metadata[1]
-		proxywasm.LogInfof("upsteam cluster matadata location[%s]=%s", string(key), string(value))
+		proxywasm.LogInfof("upstream cluster metadata location[%s]=%s", string(key), string(value))
 	}
 
 	data, err := proxywasm.GetUpstreamData(0, dataSize)


### PR DESCRIPTION
Brings https://github.com/tetratelabs/proxy-wasm-go-sdk/pull/410 to the finish line. Fixes a few typos.